### PR TITLE
fix windows cdrom type reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "cd-da-reader"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cd-da-reader"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "CD-DA (audio CD) reading library"
 repository = "https://github.com/Bloomca/rust-cd-da-reader"

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,8 +2,8 @@ use windows_sys::Win32::Foundation::{
     CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
 };
 use windows_sys::Win32::Storage::FileSystem::{
-    CreateFileW, DRIVE_CDROM, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE,
-    GetDriveTypeW, OPEN_EXISTING,
+    CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, GetDriveTypeW,
+    OPEN_EXISTING,
 };
 use windows_sys::Win32::Storage::IscsiDisc::{
     IOCTL_SCSI_PASS_THROUGH_DIRECT, SCSI_IOCTL_DATA_IN, SCSI_PASS_THROUGH_DIRECT,
@@ -22,6 +22,8 @@ pub struct SptdWithSense {
 }
 
 static mut DRIVE_HANDLE: Option<HANDLE> = None;
+// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdrivetypew#return-value
+const DRIVE_CDROM: u32 = 5;
 
 pub fn list_drive_paths() -> std::io::Result<Vec<String>> {
     let mut paths = Vec::new();


### PR DESCRIPTION
## Description

Somehow the `windows-sys` does not have the CDROM type exposed, which is just a number 5: [ref](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdrivetypew#return-value). Also bumped the patch version.