### PR TITLE
prevent rewriting macos drive

### DIFF
--- a/src/platform/macos/native/device_service.c
+++ b/src/platform/macos/native/device_service.c
@@ -32,6 +32,11 @@ Boolean open_dev_session(const char *bsdName) {
         return false;
     }
 
+    // Do not replace the device used by an existing session.
+    if (globalBsdName[0] != '\0') {
+        return strcmp(globalBsdName, bsdName) == 0;
+    }
+
     snprintf(globalBsdName, sizeof(globalBsdName), "%s", bsdName);
 
     int fd = open_cd_raw_device();


### PR DESCRIPTION
## Description

Prevent rewriting macOS drive, so if we try to open a new one while another is closed, we return unsuccessful result.