### PR TITLE
unify to list_drive_paths on macOS as well

### DIFF
--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -15,37 +15,8 @@ pub struct DriveInfo {
 
 impl CdReader {
     /// Enumerate candidate optical drives and probe whether they currently have an audio CD.
-    ///
-    /// On macOS, this uses the `IOCDMedia` objects published in the I/O Registry and
-    /// inspects their TOC property without claiming exclusive access.
-    #[cfg(target_os = "macos")]
     pub fn list_drives() -> Result<Vec<DriveInfo>, CdReaderError> {
-        crate::platform::list_drives().map_err(CdReaderError::Io)
-    }
-
-    /// Enumerate candidate optical drives and probe whether they currently have an audio CD.
-    ///
-    /// On Windows, we try to read type of every drive from A to Z. On Linux, we read
-    /// /sys/class/block directory and check every entry starting with "sr"
-    #[cfg(not(target_os = "macos"))]
-    pub fn list_drives() -> Result<Vec<DriveInfo>, CdReaderError> {
-        let mut paths = {
-            #[cfg(target_os = "windows")]
-            {
-                crate::platform::list_drive_paths().map_err(CdReaderError::Io)?
-            }
-
-            #[cfg(target_os = "linux")]
-            {
-                crate::platform::list_drive_paths().map_err(CdReaderError::Io)?
-            }
-
-            #[cfg(not(any(target_os = "windows", target_os = "linux")))]
-            {
-                compile_error!("Unsupported platform")
-            }
-        };
-
+        let mut paths = crate::platform::list_drive_paths().map_err(CdReaderError::Io)?;
         paths.sort();
         paths.dedup();
 
@@ -70,31 +41,6 @@ impl CdReader {
     }
 
     /// Open the first discovered drive that currently has an audio CD.
-    ///
-    /// On macOS, we use the passive `IOCDMedia` discovery path and then open
-    /// the matching BSD device name without claiming exclusive access.
-    #[cfg(target_os = "macos")]
-    pub fn open_default() -> Result<Self, CdReaderError> {
-        let drives = Self::list_drives()?;
-        let chosen = drives
-            .iter()
-            .find(|drive| drive.has_audio_cd)
-            .map(|drive| drive.path.as_str())
-            .ok_or_else(|| {
-                CdReaderError::Io(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "no usable audio CD drive found",
-                ))
-            })?;
-
-        Self::open(chosen).map_err(CdReaderError::Io)
-    }
-
-    /// Open the first discovered drive that currently has an audio CD.
-    ///
-    /// On Windows and Linux, we get the first device from the list and
-    /// try to open it, returning an error if it fails.
-    #[cfg(not(target_os = "macos"))]
     pub fn open_default() -> Result<Self, CdReaderError> {
         let drives = Self::list_drives()?;
         let chosen = pick_default_drive_path(&drives).ok_or_else(|| {
@@ -108,7 +54,6 @@ impl CdReader {
     }
 }
 
-#[cfg(any(test, not(target_os = "macos")))]
 fn pick_default_drive_path(drives: &[DriveInfo]) -> Option<&str> {
     drives
         .iter()

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -3,9 +3,8 @@ use std::io;
 use std::{ptr, slice};
 
 use super::ffi::{MacDriveInfo, cd_free, close_dev_session, list_cd_drives, open_dev_session};
-use crate::DriveInfo;
 
-pub(crate) fn list_drives() -> io::Result<Vec<DriveInfo>> {
+pub(crate) fn list_drive_paths() -> io::Result<Vec<String>> {
     let mut raw_drives: *mut MacDriveInfo = ptr::null_mut();
     let mut count = 0u32;
 
@@ -28,15 +27,11 @@ pub(crate) fn list_drives() -> io::Result<Vec<DriveInfo>> {
                 continue;
             }
 
-            drives.push(DriveInfo {
-                display_name: Some(path.clone()),
-                path,
-                has_audio_cd: drive.has_audio != 0,
-            });
+            drives.push(path);
         }
 
-        drives.sort_by(|left, right| left.path.cmp(&right.path));
-        drives.dedup_by(|left, right| left.path == right.path);
+        drives.sort();
+        drives.dedup();
         drives
     };
 

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -3,6 +3,6 @@ mod ffi;
 mod read_cd;
 mod toc;
 
-pub(crate) use device::{close_drive, list_drives, open_drive};
+pub(crate) use device::{close_drive, list_drive_paths, open_drive};
 pub(crate) use read_cd::read_cd_chunk;
 pub(crate) use toc::read_toc;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,7 +8,7 @@ mod windows;
 #[cfg(target_os = "linux")]
 pub(crate) use linux::{close_drive, list_drive_paths, open_drive, read_cd_chunk, read_toc};
 #[cfg(target_os = "macos")]
-pub(crate) use macos::{close_drive, list_drives, open_drive, read_cd_chunk, read_toc};
+pub(crate) use macos::{close_drive, list_drive_paths, open_drive, read_cd_chunk, read_toc};
 #[cfg(target_os = "windows")]
 pub(crate) use windows::{close_drive, list_drive_paths, open_drive, read_cd_chunk, read_toc};
 


### PR DESCRIPTION
## Description

Currently, macOS exposes a separate API `list_drives`, and Windows/Linux have `list_drive_paths`. This is mostly a historical thing, at first I didn't know that you can use APIs like `DKIOCCDREAD` which does not claim exclusivity so we don't need to unmount it. So with that in mind, we can inspect drives without downsides, so it makes sense to unify the APIs (this will be a breaking change).