### PR TITLE
Introduce drive ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,23 @@ use cd_da_reader::{CdReader};
 let drives = CdReader::list_drives()?;
 ```
 
-This will give you a vector of drives, and the struct will have `has_audio_cd` field for audio CDs.
-
-If you already know the drive name, you can open it directly:
+This gives you a vector of drives. Each entry has a `has_audio_cd` field and can
+be opened directly:
 
 ```rust
-use cd_da_reader::{CdReader};
+use cd_da_reader::CdReader;
 
-let reader = CdReader::open("disk14")?;
+let drives = CdReader::list_drives()?;
+let selected = drives.first().ok_or("no optical drives found")?;
+let reader = CdReader::open(selected)?;
+```
+
+If you already know the platform-specific device path, use `open_path`:
+
+```rust
+use cd_da_reader::CdReader;
+
+let reader = CdReader::open_path("disk14")?;
 ```
 
 ## Reading ToC

--- a/examples/list_drives.rs
+++ b/examples/list_drives.rs
@@ -11,16 +11,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Found {} drive(s):\n", drives.len());
     for drive in &drives {
-        let name = drive.display_name.as_deref().unwrap_or("(unknown)");
         let status = if drive.has_audio_cd {
             "audio CD inserted"
         } else {
             "no audio CD"
         };
-        println!(
-            "Drive: {}, name: {}, status: [{}]",
-            drive.path, name, status
-        );
+        println!("Drive: {}, status: [{status}]", drive.path);
     }
 
     Ok(())

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -7,8 +7,6 @@ pub struct DriveInfo {
     /// Path to the drive, which can be something like 'disk6' on macOS,
     /// '\\.\E:' on Windows, and '/dev/sr0' on Linux
     pub path: String,
-    /// Just the device name, without the full path for the OS
-    pub display_name: Option<String>,
     /// Whether the current disc appears to contain at least one audio track.
     pub has_audio_cd: bool,
 }
@@ -30,11 +28,7 @@ impl CdReader {
                 Err(_) => false,
             };
 
-            drives.push(DriveInfo {
-                display_name: Some(path.clone()),
-                path,
-                has_audio_cd,
-            });
+            drives.push(DriveInfo { path, has_audio_cd });
         }
 
         Ok(drives)
@@ -65,17 +59,14 @@ mod tests {
         let drives = vec![
             DriveInfo {
                 path: "disk10".to_string(),
-                display_name: None,
                 has_audio_cd: false,
             },
             DriveInfo {
                 path: "disk11".to_string(),
-                display_name: None,
                 has_audio_cd: true,
             },
             DriveInfo {
                 path: "disk12".to_string(),
-                display_name: None,
                 has_audio_cd: true,
             },
         ];
@@ -87,7 +78,6 @@ mod tests {
     fn returns_none_when_no_audio_drive() {
         let drives = vec![DriveInfo {
             path: "/dev/sr0".to_string(),
-            display_name: None,
             has_audio_cd: false,
         }];
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -16,7 +16,7 @@ pub struct DriveInfo {
 impl CdReader {
     /// Enumerate candidate optical drives and probe whether they currently have an audio CD.
     pub fn list_drives() -> Result<Vec<DriveInfo>, CdReaderError> {
-        let mut paths = crate::platform::list_drive_paths().map_err(CdReaderError::Io)?;
+        let mut paths = crate::platform::list_drive_paths()?;
         paths.sort();
         paths.dedup();
 
@@ -43,14 +43,9 @@ impl CdReader {
     /// Open the first discovered drive that currently has an audio CD.
     pub fn open_default() -> Result<Self, CdReaderError> {
         let drives = Self::list_drives()?;
-        let chosen = pick_default_drive_path(&drives).ok_or_else(|| {
-            CdReaderError::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "no usable audio CD drive found",
-            ))
-        })?;
+        let chosen = pick_default_drive_path(&drives).ok_or(CdReaderError::NoUsableDrive)?;
 
-        Self::open(chosen).map_err(CdReaderError::Io)
+        Self::open(chosen)
     }
 }
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -20,7 +20,7 @@ impl CdReader {
 
         let mut drives = Vec::with_capacity(paths.len());
         for path in paths {
-            let has_audio_cd = match Self::open(&path) {
+            let has_audio_cd = match Self::open_path(&path) {
                 Ok(reader) => match reader.read_toc() {
                     Ok(toc) => toc.tracks.iter().any(|track| track.is_audio),
                     Err(_) => false,
@@ -37,22 +37,19 @@ impl CdReader {
     /// Open the first discovered drive that currently has an audio CD.
     pub fn open_default() -> Result<Self, CdReaderError> {
         let drives = Self::list_drives()?;
-        let chosen = pick_default_drive_path(&drives).ok_or(CdReaderError::NoUsableDrive)?;
+        let chosen = pick_default_drive(&drives).ok_or(CdReaderError::NoUsableDrive)?;
 
         Self::open(chosen)
     }
 }
 
-fn pick_default_drive_path(drives: &[DriveInfo]) -> Option<&str> {
-    drives
-        .iter()
-        .find(|drive| drive.has_audio_cd)
-        .map(|drive| drive.path.as_str())
+fn pick_default_drive(drives: &[DriveInfo]) -> Option<&DriveInfo> {
+    drives.iter().find(|drive| drive.has_audio_cd)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DriveInfo, pick_default_drive_path};
+    use super::{DriveInfo, pick_default_drive};
 
     #[test]
     fn chooses_first_audio_drive() {
@@ -71,7 +68,10 @@ mod tests {
             },
         ];
 
-        assert_eq!(pick_default_drive_path(&drives), Some("disk11"));
+        assert_eq!(
+            pick_default_drive(&drives).map(|drive| drive.path.as_str()),
+            Some("disk11")
+        );
     }
 
     #[test]
@@ -81,6 +81,6 @@ mod tests {
             has_audio_cd: false,
         }];
 
-        assert_eq!(pick_default_drive_path(&drives), None);
+        assert!(pick_default_drive(&drives).is_none());
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,6 +42,8 @@ pub enum CdReaderError {
     Scsi(ScsiError),
     /// Parsing failure for command payloads (TOC/CD-TEXT/subchannel parsing).
     Parse(String),
+    /// Drive enumeration completed without finding a usable audio CD.
+    NoUsableDrive,
 }
 
 impl fmt::Display for CdReaderError {
@@ -54,11 +56,19 @@ impl fmt::Display for CdReaderError {
                 err.op, err.scsi_status, err.lba, err.sectors, err.sense_key, err.asc, err.ascq
             ),
             Self::Parse(msg) => write!(f, "parse error: {msg}"),
+            Self::NoUsableDrive => write!(f, "no usable audio CD drive found"),
         }
     }
 }
 
-impl std::error::Error for CdReaderError {}
+impl std::error::Error for CdReaderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Scsi(_) | Self::Parse(_) | Self::NoUsableDrive => None,
+        }
+    }
+}
 
 impl From<std::io::Error> for CdReaderError {
     fn from(value: std::io::Error) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,13 +191,12 @@ pub struct Toc {
     pub leadout_lba: u32,
 }
 
-/// Helper struct to interact with the audio CD. While it doesn't hold any internal data
-/// directly, it implements `Drop` trait, so that the CD drive handle is properly closed.
-///
-/// Please note that you should not read multiple CDs at the same time, and preferably do
-/// not use it in multiple threads. CD drives are physical devices, so currently only
-/// sequential access is properly tested and supported.
-pub struct CdReader {}
+/// Helper struct to interact with the audio CD. Internally it holds a platform-specific
+/// handle to the open CD drive to read from it and it is correctly closed when CDReader
+/// is dropped.
+pub struct CdReader {
+    drive: platform::Drive,
+}
 
 impl CdReader {
     /// Opens a CD drive at the specified path in order to read data.
@@ -216,8 +215,16 @@ impl CdReader {
     ///
     /// Returns an error if the drive cannot be opened
     pub fn open(path: &str) -> std::io::Result<Self> {
-        platform::open_drive(path)?;
-        Ok(Self {})
+        Ok(Self {
+            drive: platform::Drive::open(path)?,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_reader() -> Self {
+        Self {
+            drive: platform::Drive::test_drive(),
+        }
     }
 
     /// While this is a low-level library and does not include any codecs to compress the audio,
@@ -239,7 +246,7 @@ impl CdReader {
     /// when calling `read_track`, as it doesn't start with 0. It is important to do so,
     /// because in the future it might include 0 for the hidden track.
     pub fn read_toc(&self) -> Result<Toc, CdReaderError> {
-        platform::read_toc()
+        self.drive.read_toc()
     }
 
     /// Read raw data for the specified track number from the TOC.
@@ -285,13 +292,7 @@ impl CdReader {
         cfg: &RetryConfig,
     ) -> Result<Vec<u8>, CdReaderError> {
         read_loop::read_sectors_chunked(start_lba, sectors, mode, cfg, |lba, chunk_sectors| {
-            platform::read_cd_chunk(lba, chunk_sectors, mode)
+            self.drive.read_cd_chunk(lba, chunk_sectors, mode)
         })
-    }
-}
-
-impl Drop for CdReader {
-    fn drop(&mut self) {
-        platform::close_drive();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,21 +26,19 @@
 //! ```
 //!
 //! If you need to pick a specific drive, use [`CdReader::list_drives`] followed
-//! by calling [`CdReader::open`] with the specific drive:
+//! by calling [`CdReader::open`] with the selected drive:
 //!
 //! ```no_run
 //! use cd_da_reader::CdReader;
 //!
-//! // Windows / Linux: enumerate drives and inspect the has_audio_cd field
 //! let drives = CdReader::list_drives()?;
-//!
-//! // Any platform: open a known path directly
-//! // Windows:  r"\\.\E:"
-//! // macOS:    "disk6"
-//! // Linux:    "/dev/sr0"
-//! let reader = CdReader::open("disk6")?;
+//! let selected = drives.first().ok_or("no optical drives found")?;
+//! let reader = CdReader::open(selected)?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
+//!
+//! If you already know the platform-specific device path, use
+//! [`CdReader::open_path`] instead.
 //!
 //! ## Reading ToC
 //!
@@ -199,22 +197,18 @@ pub struct CdReader {
 }
 
 impl CdReader {
-    /// Opens a CD drive at the specified path in order to read data.
+    /// Opens a drive returned by [`CdReader::list_drives`].
     ///
-    /// It is crucial to call this function and not to create the Reader
-    /// by yourself, as each OS needs its own way of handling the drive access.
+    /// The reader owns the opened drive until it is dropped.
+    pub fn open(drive: &DriveInfo) -> Result<Self, CdReaderError> {
+        Self::open_path(&drive.path)
+    }
+
+    /// Opens a CD drive at a platform-specific device path.
     ///
-    /// You don't need to close the drive; it will be handled automatically
-    /// when the `CdReader` is dropped.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The device path (e.g., "/dev/sr0" on Linux, "disk6" on macOS, and r"\\.\E:" on Windows)
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the drive cannot be opened
-    pub fn open(path: &str) -> Result<Self, CdReaderError> {
+    /// Example paths are `/dev/sr0` on Linux, `disk6` on macOS, and
+    /// `\\.\E:` on Windows. The reader owns the opened drive until it is dropped.
+    pub fn open_path(path: &str) -> Result<Self, CdReaderError> {
         Ok(Self {
             drive: platform::Drive::open(path)?,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ impl CdReader {
     /// # Errors
     ///
     /// Returns an error if the drive cannot be opened
-    pub fn open(path: &str) -> std::io::Result<Self> {
+    pub fn open(path: &str) -> Result<Self, CdReaderError> {
         Ok(Self {
             drive: platform::Drive::open(path)?,
         })

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -5,7 +5,40 @@ use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::path::Path;
 
-static mut DRIVE_HANDLE: Option<File> = None;
+pub(crate) struct Drive {
+    // file closes the file descriptor on drop automatically
+    file: File,
+}
+
+impl Drive {
+    pub(crate) fn open(path: &str) -> io::Result<Self> {
+        let path = CString::new(path).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "drive path contains an interior NUL byte",
+            )
+        })?;
+        let fd = unsafe { libc::open(path.as_ptr(), O_RDWR | O_NONBLOCK) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            file: unsafe { File::from_raw_fd(fd) },
+        })
+    }
+
+    pub(super) fn fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_drive() -> Self {
+        Self {
+            file: File::open("/dev/null").expect("could not open /dev/null for tests"),
+        }
+    }
+}
 
 pub(crate) fn list_drive_paths() -> io::Result<Vec<String>> {
     let mut drives = Vec::new();
@@ -27,43 +60,4 @@ pub(crate) fn list_drive_paths() -> io::Result<Vec<String>> {
     drives.sort();
     drives.dedup();
     Ok(drives)
-}
-
-pub(crate) fn open_drive(path: &str) -> io::Result<()> {
-    let path = CString::new(path).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "drive path contains an interior NUL byte",
-        )
-    })?;
-    let fd = unsafe { libc::open(path.as_ptr(), O_RDWR | O_NONBLOCK) };
-    if fd < 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    let drive_handle = unsafe { File::from_raw_fd(fd) };
-    unsafe {
-        DRIVE_HANDLE = Some(drive_handle);
-    }
-
-    Ok(())
-}
-
-#[allow(static_mut_refs)]
-pub(crate) fn close_drive() {
-    unsafe {
-        if let Some(current_drive) = DRIVE_HANDLE.take() {
-            drop(current_drive);
-        }
-    }
-}
-
-#[allow(static_mut_refs)]
-pub(super) fn drive_fd() -> io::Result<RawFd> {
-    unsafe {
-        DRIVE_HANDLE
-            .as_ref()
-            .map(AsRawFd::as_raw_fd)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Drive not opened"))
-    }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -3,6 +3,21 @@ mod read_cd;
 mod sg_io;
 mod toc;
 
-pub(crate) use device::{close_drive, list_drive_paths, open_drive};
-pub(crate) use read_cd::read_cd_chunk;
-pub(crate) use toc::read_toc;
+pub(crate) use device::{Drive, list_drive_paths};
+
+use crate::{CdReaderError, SectorReadMode, Toc};
+
+impl Drive {
+    pub(crate) fn read_toc(&self) -> Result<Toc, CdReaderError> {
+        toc::read_toc(self)
+    }
+
+    pub(crate) fn read_cd_chunk(
+        &self,
+        lba: u32,
+        sectors: u32,
+        mode: SectorReadMode,
+    ) -> Result<Vec<u8>, CdReaderError> {
+        read_cd::read_cd_chunk(self, lba, sectors, mode)
+    }
+}

--- a/src/platform/linux/read_cd.rs
+++ b/src/platform/linux/read_cd.rs
@@ -1,10 +1,12 @@
+use super::device::Drive;
 use super::sg_io::{CommandContext, execute_read};
 use crate::data_reader::{SectorReadMode, build_read_cd_cdb};
 use crate::{CdReaderError, ScsiOp};
 
 const READ_CD_TIMEOUT_MS: u32 = 30_000;
 
-pub(crate) fn read_cd_chunk(
+pub(super) fn read_cd_chunk(
+    drive: &Drive,
     lba: u32,
     sectors: u32,
     mode: SectorReadMode,
@@ -12,6 +14,7 @@ pub(crate) fn read_cd_chunk(
     let mut chunk = vec![0u8; sectors as usize * mode.sector_size()];
     let mut cdb = build_read_cd_cdb(lba, sectors, mode);
     let transferred = execute_read(
+        drive.fd(),
         &mut cdb,
         &mut chunk,
         READ_CD_TIMEOUT_MS,

--- a/src/platform/linux/sg_io.rs
+++ b/src/platform/linux/sg_io.rs
@@ -1,6 +1,6 @@
 use libc::{c_uchar, c_void};
+use std::os::fd::RawFd;
 
-use super::device;
 use crate::{CdReaderError, ScsiError, ScsiOp};
 
 const SG_INFO_CHECK: u32 = 0x1;
@@ -46,6 +46,7 @@ pub(super) struct CommandContext {
 
 /// Execute a single SCSI read command and return the number of bytes transferred.
 pub(super) fn execute_read(
+    fd: RawFd,
     cdb: &mut [u8],
     output: &mut [u8],
     timeout_ms: u32,
@@ -84,7 +85,6 @@ pub(super) fn execute_read(
         info: 0,
     };
 
-    let fd = device::drive_fd().map_err(CdReaderError::Io)?;
     let result = unsafe { libc::ioctl(fd, SG_IO, &mut header as *mut _) };
     if result < 0 {
         return Err(CdReaderError::Io(std::io::Error::last_os_error()));

--- a/src/platform/linux/toc.rs
+++ b/src/platform/linux/toc.rs
@@ -1,3 +1,4 @@
+use super::device::Drive;
 use super::sg_io::{CommandContext, execute_read};
 use crate::parse_toc::parse_toc;
 use crate::{CdReaderError, ScsiOp, Toc};
@@ -5,10 +6,11 @@ use crate::{CdReaderError, ScsiOp, Toc};
 const TOC_BUFFER_SIZE: usize = 2048;
 const TOC_TIMEOUT_MS: u32 = 10_000;
 
-pub(crate) fn read_toc() -> Result<Toc, CdReaderError> {
+pub(super) fn read_toc(drive: &Drive) -> Result<Toc, CdReaderError> {
     let mut data = vec![0u8; TOC_BUFFER_SIZE];
     let mut cdb = build_read_toc_cdb(TOC_BUFFER_SIZE);
     let transferred = execute_read(
+        drive.fd(),
         &mut cdb,
         &mut data,
         TOC_TIMEOUT_MS,

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -1,8 +1,45 @@
 use std::ffi::{CStr, CString};
+use std::fs::File;
 use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::{ptr, slice};
 
-use super::ffi::{MacDriveInfo, cd_free, close_dev_session, list_cd_drives, open_dev_session};
+use super::ffi::{MacDriveInfo, cd_free, list_cd_drives, open_cd_raw_device};
+
+pub(crate) struct Drive {
+    // file closes the file descriptor on drop automatically
+    file: File,
+}
+
+impl Drive {
+    pub(crate) fn open(path: &str) -> io::Result<Self> {
+        let bsd_name = CString::new(path).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "drive path contains an interior NUL byte",
+            )
+        })?;
+        let fd = unsafe { open_cd_raw_device(bsd_name.as_ptr()) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            file: unsafe { File::from_raw_fd(fd) },
+        })
+    }
+
+    pub(super) fn fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_drive() -> Self {
+        Self {
+            file: File::open("/dev/null").expect("could not open /dev/null for tests"),
+        }
+    }
+}
 
 pub(crate) fn list_drive_paths() -> io::Result<Vec<String>> {
     let mut raw_drives: *mut MacDriveInfo = ptr::null_mut();
@@ -38,24 +75,4 @@ pub(crate) fn list_drive_paths() -> io::Result<Vec<String>> {
     unsafe { cd_free(raw_drives.cast()) };
 
     Ok(drives)
-}
-
-pub(crate) fn open_drive(path: &str) -> io::Result<()> {
-    let bsd_name = CString::new(path).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "drive path contains an interior NUL byte",
-        )
-    })?;
-    let success = unsafe { open_dev_session(bsd_name.as_ptr()) };
-
-    if !success {
-        return Err(io::Error::other("could not get device"));
-    }
-
-    Ok(())
-}
-
-pub(crate) fn close_drive() {
-    unsafe { close_dev_session() };
 }

--- a/src/platform/macos/ffi.rs
+++ b/src/platform/macos/ffi.rs
@@ -17,8 +17,6 @@ pub(super) struct MacScsiError {
 #[derive(Debug, Clone, Copy)]
 pub(super) struct MacDriveInfo {
     pub(super) bsd_name: [libc::c_char; 64],
-    pub(super) has_toc: u8,
-    pub(super) has_audio: u8,
 }
 
 #[link(name = "macos_cd_shim", kind = "static")]

--- a/src/platform/macos/ffi.rs
+++ b/src/platform/macos/ffi.rs
@@ -24,11 +24,13 @@ pub(super) struct MacDriveInfo {
 #[link(name = "macos_cd_shim", kind = "static")]
 unsafe extern "C" {
     pub(super) fn cd_read_toc(
+        fd: libc::c_int,
         out_buf: *mut *mut u8,
         out_len: *mut u32,
         out_err: *mut MacScsiError,
     ) -> bool;
     pub(super) fn read_cd_sectors(
+        fd: libc::c_int,
         lba: u32,
         sectors: u32,
         mode_id: u32,
@@ -38,8 +40,7 @@ unsafe extern "C" {
     ) -> bool;
     pub(super) fn cd_free(pointer: *mut libc::c_void);
     pub(super) fn list_cd_drives(out_drives: *mut *mut MacDriveInfo, out_count: *mut u32) -> bool;
-    pub(super) fn open_dev_session(bsd_name: *const libc::c_char) -> bool;
-    pub(super) fn close_dev_session();
+    pub(super) fn open_cd_raw_device(bsd_name: *const libc::c_char) -> libc::c_int;
 }
 
 pub(super) fn map_error(

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -3,6 +3,21 @@ mod ffi;
 mod read_cd;
 mod toc;
 
-pub(crate) use device::{close_drive, list_drive_paths, open_drive};
-pub(crate) use read_cd::read_cd_chunk;
-pub(crate) use toc::read_toc;
+pub(crate) use device::{Drive, list_drive_paths};
+
+use crate::{CdReaderError, SectorReadMode, Toc};
+
+impl Drive {
+    pub(crate) fn read_toc(&self) -> Result<Toc, CdReaderError> {
+        toc::read_toc(self)
+    }
+
+    pub(crate) fn read_cd_chunk(
+        &self,
+        lba: u32,
+        sectors: u32,
+        mode: SectorReadMode,
+    ) -> Result<Vec<u8>, CdReaderError> {
+        read_cd::read_cd_chunk(self, lba, sectors, mode)
+    }
+}

--- a/src/platform/macos/native/device_service.c
+++ b/src/platform/macos/native/device_service.c
@@ -1,54 +1,22 @@
 #include "shim_common.h"
 
-char globalBsdName[64] = {0};
-
-int open_cd_raw_device(void) {
-    if (globalBsdName[0] == '\0') {
+int open_cd_raw_device(const char *bsdName) {
+    if (!bsdName || bsdName[0] == '\0') {
         errno = ENODEV;
         return -1;
     }
 
     char path[96];
-    if (strncmp(globalBsdName, "/dev/rdisk", 10) == 0) {
-        snprintf(path, sizeof(path), "%s", globalBsdName);
-    } else if (strncmp(globalBsdName, "/dev/disk", 9) == 0) {
-        snprintf(path, sizeof(path), "/dev/r%s", globalBsdName + 5);
-    } else if (strncmp(globalBsdName, "rdisk", 5) == 0) {
-        snprintf(path, sizeof(path), "/dev/%s", globalBsdName);
+    if (strncmp(bsdName, "/dev/rdisk", 10) == 0) {
+        snprintf(path, sizeof(path), "%s", bsdName);
+    } else if (strncmp(bsdName, "/dev/disk", 9) == 0) {
+        snprintf(path, sizeof(path), "/dev/r%s", bsdName + 5);
+    } else if (strncmp(bsdName, "rdisk", 5) == 0) {
+        snprintf(path, sizeof(path), "/dev/%s", bsdName);
     } else {
-        snprintf(path, sizeof(path), "/dev/r%s", globalBsdName);
+        snprintf(path, sizeof(path), "/dev/r%s", bsdName);
     }
 
+    // important not to open with a write flag so it does not need exclusivity
     return open(path, O_RDONLY | O_NONBLOCK);
-}
-
-// Reading the TOC and sector data both go through the read-only
-// DKIOCCDREAD/DKIOCCDREADTOC ioctls on the raw BSD device, so opening a
-// "session" is just remembering which device to open. This avoids the
-// SCSITaskDeviceInterface path, which requires exclusive access and forces
-// the volume to unmount. We validate the name by opening the raw device once.
-Boolean open_dev_session(const char *bsdName) {
-    if (!bsdName || bsdName[0] == '\0') {
-        return false;
-    }
-
-    // Do not replace the device used by an existing session.
-    if (globalBsdName[0] != '\0') {
-        return strcmp(globalBsdName, bsdName) == 0;
-    }
-
-    snprintf(globalBsdName, sizeof(globalBsdName), "%s", bsdName);
-
-    int fd = open_cd_raw_device();
-    if (fd < 0) {
-        globalBsdName[0] = '\0';
-        return false;
-    }
-    close(fd);
-
-    return true;
-}
-
-void close_dev_session(void) {
-    globalBsdName[0] = '\0';
 }

--- a/src/platform/macos/native/list_drives.c
+++ b/src/platform/macos/native/list_drives.c
@@ -24,74 +24,6 @@ static bool copy_bsd_name(io_service_t media, char *outName, size_t outNameLen) 
     return ok;
 }
 
-static bool toc_has_audio_track(CFDataRef tocData) {
-    if (!tocData) {
-        return false;
-    }
-
-    CFIndex len = CFDataGetLength(tocData);
-    if (len < (CFIndex)sizeof(CDTOC)) {
-        return false;
-    }
-
-    CDTOC *toc = (CDTOC *)CFDataGetBytePtr(tocData);
-    uint16_t tocLength = OSSwapBigToHostInt16(toc->length);
-    size_t tocSize = (size_t)tocLength + sizeof(toc->length);
-    if (tocSize > (size_t)len) {
-        return false;
-    }
-
-    UInt32 count = CDTOCGetDescriptorCount(toc);
-    for (UInt32 i = 0; i < count; i++) {
-        CDTOCDescriptor *desc = &toc->descriptors[i];
-        if (desc->adr != 1) {
-            continue;
-        }
-
-        // Format 0x02 includes A0/A1/A2 metadata descriptors; real tracks are 1..99.
-        if (desc->point < 1 || desc->point > 99) {
-            continue;
-        }
-
-        if ((desc->control & 0x04) == 0) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-static bool inspect_toc(io_service_t media, uint8_t *hasToc, uint8_t *hasAudio) {
-    if (hasToc) {
-        *hasToc = 0;
-    }
-    if (hasAudio) {
-        *hasAudio = 0;
-    }
-
-    CFTypeRef toc = IORegistryEntryCreateCFProperty(
-        media,
-        CFSTR(kIOCDMediaTOCKey),
-        kCFAllocatorDefault,
-        0
-    );
-    if (!toc) {
-        return true;
-    }
-
-    if (CFGetTypeID(toc) == CFDataGetTypeID()) {
-        if (hasToc) {
-            *hasToc = 1;
-        }
-        if (hasAudio && toc_has_audio_track((CFDataRef)toc)) {
-            *hasAudio = 1;
-        }
-    }
-
-    CFRelease(toc);
-    return true;
-}
-
 bool list_cd_drives(CdDriveInfo **outDrives, uint32_t *outCount) {
     if (!outDrives || !outCount) {
         return false;
@@ -120,8 +52,6 @@ bool list_cd_drives(CdDriveInfo **outDrives, uint32_t *outCount) {
         memset(&info, 0, sizeof(info));
 
         if (copy_bsd_name(media, info.bsd_name, sizeof(info.bsd_name))) {
-            inspect_toc(media, &info.has_toc, &info.has_audio);
-
             CdDriveInfo *next = realloc(drives, (count + 1) * sizeof(CdDriveInfo));
             if (!next) {
                 IOObjectRelease(media);

--- a/src/platform/macos/native/read_cd.c
+++ b/src/platform/macos/native/read_cd.c
@@ -33,7 +33,7 @@ static bool sector_layout_for_mode(uint32_t mode_id,
     }
 }
 
-bool read_cd_sectors(uint32_t lba, uint32_t sectors, uint32_t mode_id,
+bool read_cd_sectors(int fd, uint32_t lba, uint32_t sectors, uint32_t mode_id,
                      uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr) {
     *outBuf = NULL;
     *outLen = 0;
@@ -67,13 +67,6 @@ bool read_cd_sectors(uint32_t lba, uint32_t sectors, uint32_t mode_id,
         goto fail;
     }
 
-    int fd = open_cd_raw_device();
-    if (fd < 0) {
-        fprintf(stderr, "[READ] open raw CD device failed (errno=%d)\n", errno);
-        free(dst);
-        goto fail;
-    }
-
     dk_cd_read_t read = {0};
     read.offset = (uint64_t)lba * (uint64_t)sectorSize;
     read.sectorArea = sectorArea;
@@ -82,7 +75,6 @@ bool read_cd_sectors(uint32_t lba, uint32_t sectors, uint32_t mode_id,
     read.buffer = dst;
 
     int ret = ioctl(fd, DKIOCCDREAD, &read);
-    close(fd);
 
     if (ret < 0) {
         fprintf(stderr, "[READ] DKIOCCDREAD failed (errno=%d)\n", errno);

--- a/src/platform/macos/native/shim_common.h
+++ b/src/platform/macos/native/shim_common.h
@@ -34,16 +34,12 @@ typedef struct {
     uint8_t has_audio;
 } CdDriveInfo;
 
-extern char globalBsdName[64];
-
-bool cd_read_toc(uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);
-bool read_cd_sectors(uint32_t lba, uint32_t sectors, uint32_t mode_id, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);
+bool cd_read_toc(int fd, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);
+bool read_cd_sectors(int fd, uint32_t lba, uint32_t sectors, uint32_t mode_id, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);
 void cd_free(void *p);
 
 bool list_cd_drives(CdDriveInfo **outDrives, uint32_t *outCount);
 
-int open_cd_raw_device(void);
-Boolean open_dev_session(const char *bsdName);
-void close_dev_session(void);
+int open_cd_raw_device(const char *bsdName);
 
 #endif

--- a/src/platform/macos/native/shim_common.h
+++ b/src/platform/macos/native/shim_common.h
@@ -30,8 +30,6 @@ typedef struct {
 
 typedef struct {
     char bsd_name[64];
-    uint8_t has_toc;
-    uint8_t has_audio;
 } CdDriveInfo;
 
 bool cd_read_toc(int fd, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);

--- a/src/platform/macos/native/toc_reader.c
+++ b/src/platform/macos/native/toc_reader.c
@@ -1,22 +1,15 @@
 #include "shim_common.h"
 
-static Boolean read_toc(uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr) {
+static Boolean read_toc(int fd, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr) {
     *outBuf = NULL;
     *outLen = 0;
     if (outErr) {
         memset(outErr, 0, sizeof(CdScsiError));
     }
 
-    int fd = open_cd_raw_device();
-    if (fd < 0) {
-        fprintf(stderr, "[TOC] open raw CD device failed (errno=%d)\n", errno);
-        goto fail;
-    }
-
     const uint16_t rawAlloc = 4096;
     uint8_t *raw = malloc(rawAlloc);
     if (!raw) {
-        close(fd);
         fprintf(stderr, "[TOC] oom\n");
         goto fail;
     }
@@ -29,7 +22,6 @@ static Boolean read_toc(uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr)
     request.buffer = raw;
 
     int ret = ioctl(fd, DKIOCCDREADTOC, &request);
-    close(fd);
 
     if (ret < 0) {
         fprintf(stderr, "[TOC] DKIOCCDREADTOC failed (errno=%d)\n", errno);
@@ -138,8 +130,8 @@ fail:
     return false;
 }
 
-bool cd_read_toc(uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr) {
-    return read_toc(outBuf, outLen, outErr);
+bool cd_read_toc(int fd, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr) {
+    return read_toc(fd, outBuf, outLen, outErr);
 }
 
 void cd_free(void *p) {

--- a/src/platform/macos/read_cd.rs
+++ b/src/platform/macos/read_cd.rs
@@ -1,9 +1,11 @@
 use std::{ptr, slice};
 
+use super::device::Drive;
 use super::ffi::{MacScsiError, cd_free, map_error, read_cd_sectors};
 use crate::{CdReaderError, ScsiOp, SectorReadMode};
 
-pub(crate) fn read_cd_chunk(
+pub(super) fn read_cd_chunk(
+    drive: &Drive,
     lba: u32,
     sectors: u32,
     mode: SectorReadMode,
@@ -14,6 +16,7 @@ pub(crate) fn read_cd_chunk(
 
     let success = unsafe {
         read_cd_sectors(
+            drive.fd(),
             lba,
             sectors,
             mode_id(mode),

--- a/src/platform/macos/toc.rs
+++ b/src/platform/macos/toc.rs
@@ -1,15 +1,16 @@
 use std::{ptr, slice};
 
+use super::device::Drive;
 use super::ffi::{MacScsiError, cd_free, cd_read_toc, map_error};
 use crate::parse_toc::parse_toc;
 use crate::{CdReaderError, ScsiOp, Toc};
 
-pub(crate) fn read_toc() -> Result<Toc, CdReaderError> {
+pub(super) fn read_toc(drive: &Drive) -> Result<Toc, CdReaderError> {
     let mut buffer: *mut u8 = ptr::null_mut();
     let mut len = 0u32;
     let mut error = MacScsiError::default();
 
-    let success = unsafe { cd_read_toc(&mut buffer, &mut len, &mut error) };
+    let success = unsafe { cd_read_toc(drive.fd(), &mut buffer, &mut len, &mut error) };
     if !success {
         return Err(map_error(error, ScsiOp::ReadToc, None, None));
     }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -6,11 +6,11 @@ mod macos;
 mod windows;
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::{close_drive, list_drive_paths, open_drive, read_cd_chunk, read_toc};
+pub(crate) use linux::{Drive, list_drive_paths};
 #[cfg(target_os = "macos")]
-pub(crate) use macos::{close_drive, list_drive_paths, open_drive, read_cd_chunk, read_toc};
+pub(crate) use macos::{Drive, list_drive_paths};
 #[cfg(target_os = "windows")]
-pub(crate) use windows::{close_drive, list_drive_paths, open_drive, read_cd_chunk, read_toc};
+pub(crate) use windows::{Drive, list_drive_paths};
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 compile_error!("Unsupported platform");

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -1,9 +1,8 @@
 use std::io;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
 use std::ptr;
 
-use windows_sys::Win32::Foundation::{
-    CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
-};
+use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::Storage::FileSystem::{
     CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, GetDriveTypeW,
     OPEN_EXISTING,
@@ -12,7 +11,45 @@ use windows_sys::Win32::Storage::FileSystem::{
 // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdrivetypew#return-value
 const DRIVE_CDROM: u32 = 5;
 
-static mut DRIVE_HANDLE: Option<HANDLE> = None;
+pub(crate) struct Drive {
+    // https://doc.rust-lang.org/beta/std/os/windows/io/struct.OwnedHandle.html
+    // OwnedHandle automatically closes the handle on drop
+    handle: OwnedHandle,
+}
+
+impl Drive {
+    pub(crate) fn open(path: &str) -> io::Result<Self> {
+        let path: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ptr::null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                ptr::null_mut(),
+            )
+        };
+
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            handle: unsafe { OwnedHandle::from_raw_handle(handle) },
+        })
+    }
+
+    pub(super) fn handle(&self) -> HANDLE {
+        self.handle.as_raw_handle()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_drive() -> Self {
+        Self::open("NUL").expect("could not open NUL device for tests")
+    }
+}
 
 pub(crate) fn list_drive_paths() -> io::Result<Vec<String>> {
     let mut paths = Vec::new();
@@ -31,51 +68,4 @@ pub(crate) fn list_drive_paths() -> io::Result<Vec<String>> {
     }
 
     Ok(paths)
-}
-
-#[allow(static_mut_refs)]
-pub(crate) fn open_drive(path: &str) -> io::Result<()> {
-    unsafe {
-        if DRIVE_HANDLE.is_some() {
-            return Err(io::Error::other("Drive is already open"));
-        }
-    }
-
-    let path: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
-    let handle = unsafe {
-        CreateFileW(
-            path.as_ptr(),
-            GENERIC_READ | GENERIC_WRITE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE,
-            ptr::null(),
-            OPEN_EXISTING,
-            FILE_ATTRIBUTE_NORMAL,
-            ptr::null_mut(),
-        )
-    };
-
-    if handle == INVALID_HANDLE_VALUE {
-        return Err(io::Error::last_os_error());
-    }
-
-    unsafe {
-        DRIVE_HANDLE = Some(handle);
-    }
-
-    Ok(())
-}
-
-pub(crate) fn close_drive() {
-    unsafe {
-        if let Some(handle) = DRIVE_HANDLE {
-            CloseHandle(handle);
-            DRIVE_HANDLE = None;
-        }
-    }
-}
-
-pub(super) fn drive_handle() -> io::Result<HANDLE> {
-    unsafe {
-        DRIVE_HANDLE.ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Drive not opened"))
-    }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -3,6 +3,21 @@ mod read_cd;
 mod spti;
 mod toc;
 
-pub(crate) use device::{close_drive, list_drive_paths, open_drive};
-pub(crate) use read_cd::read_cd_chunk;
-pub(crate) use toc::read_toc;
+pub(crate) use device::{Drive, list_drive_paths};
+
+use crate::{CdReaderError, SectorReadMode, Toc};
+
+impl Drive {
+    pub(crate) fn read_toc(&self) -> Result<Toc, CdReaderError> {
+        toc::read_toc(self)
+    }
+
+    pub(crate) fn read_cd_chunk(
+        &self,
+        lba: u32,
+        sectors: u32,
+        mode: SectorReadMode,
+    ) -> Result<Vec<u8>, CdReaderError> {
+        read_cd::read_cd_chunk(self, lba, sectors, mode)
+    }
+}

--- a/src/platform/windows/read_cd.rs
+++ b/src/platform/windows/read_cd.rs
@@ -1,10 +1,12 @@
+use super::device::Drive;
 use super::spti::{CommandContext, execute_read};
 use crate::data_reader::{SectorReadMode, build_read_cd_cdb};
 use crate::{CdReaderError, ScsiOp};
 
 const READ_CD_TIMEOUT_SECONDS: u32 = 30;
 
-pub(crate) fn read_cd_chunk(
+pub(super) fn read_cd_chunk(
+    drive: &Drive,
     lba: u32,
     sectors: u32,
     mode: SectorReadMode,
@@ -12,6 +14,7 @@ pub(crate) fn read_cd_chunk(
     let mut chunk = vec![0u8; sectors as usize * mode.sector_size()];
     let cdb = build_read_cd_cdb(lba, sectors, mode);
     let transferred = execute_read(
+        drive.handle(),
         &cdb,
         &mut chunk,
         READ_CD_TIMEOUT_SECONDS,

--- a/src/platform/windows/spti.rs
+++ b/src/platform/windows/spti.rs
@@ -1,12 +1,12 @@
 use std::mem::{offset_of, size_of};
 use std::ptr;
 
+use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::IscsiDisc::{
     IOCTL_SCSI_PASS_THROUGH_DIRECT, SCSI_IOCTL_DATA_IN, SCSI_PASS_THROUGH_DIRECT,
 };
 use windows_sys::Win32::System::IO::DeviceIoControl;
 
-use super::device;
 use crate::{CdReaderError, ScsiError, ScsiOp};
 
 const SENSE_BUFFER_SIZE: usize = 32;
@@ -26,6 +26,7 @@ pub(super) struct CommandContext {
 
 /// Execute one SCSI read through Windows SPTI and return the transferred byte count.
 pub(super) fn execute_read(
+    handle: HANDLE,
     cdb: &[u8],
     output: &mut [u8],
     timeout_seconds: u32,
@@ -37,7 +38,6 @@ pub(super) fn execute_read(
 
     let transfer_len = u32::try_from(output.len())
         .map_err(|_| invalid_input("SCSI transfer buffer is too large"))?;
-    let handle = device::drive_handle().map_err(CdReaderError::Io)?;
     let mut wrapper: SptdWithSense = unsafe { std::mem::zeroed() };
 
     wrapper.sptd.Length = size_of::<SCSI_PASS_THROUGH_DIRECT>() as u16;

--- a/src/platform/windows/toc.rs
+++ b/src/platform/windows/toc.rs
@@ -1,3 +1,4 @@
+use super::device::Drive;
 use super::spti::{CommandContext, execute_read};
 use crate::parse_toc::parse_toc;
 use crate::{CdReaderError, ScsiOp, Toc};
@@ -5,10 +6,11 @@ use crate::{CdReaderError, ScsiOp, Toc};
 const TOC_BUFFER_SIZE: usize = 2048;
 const TOC_TIMEOUT_SECONDS: u32 = 10;
 
-pub(crate) fn read_toc() -> Result<Toc, CdReaderError> {
+pub(super) fn read_toc(drive: &Drive) -> Result<Toc, CdReaderError> {
     let mut data = vec![0u8; TOC_BUFFER_SIZE];
     let cdb = build_read_toc_cdb(TOC_BUFFER_SIZE);
     let transferred = execute_read(
+        drive.handle(),
         &cdb,
         &mut data,
         TOC_TIMEOUT_SECONDS,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -166,7 +166,7 @@ mod tests {
         total_sectors: u32,
         sectors_per_chunk: u32,
     ) -> TrackStream<'static> {
-        let reader: &'static CdReader = Box::leak(Box::new(CdReader {}));
+        let reader: &'static CdReader = Box::leak(Box::new(CdReader::test_reader()));
         TrackStream {
             reader,
             start_lba,


### PR DESCRIPTION
## Description

Historically this library opened a single handle/file descriptor for the CD drive and kept it globally. This represented a few issues:

- opening another CD reader would cause issues with overriding the existing handle and potentially closing the handle early
- the lifecycle was a bit awkward because of that

This change adds a new (private) struct for Drive so that the handle/FD is owned by that struct directly, which especially helps with the macOS implementation which previously opened and closed FD for each chunk. While it was unlikely to be the bottleneck, moving between kernel and userland that often was still causing some wait times.

This PR also unifies the `list_drives()` API, now it works the same across all platforms.