### PR TITLE
Refactor reading api

### DIFF
--- a/examples/custom_retry.rs
+++ b/examples/custom_retry.rs
@@ -3,7 +3,7 @@
 /// By default, it already retries multiple times with smaller number
 /// of sectors, so this usually should not be necessary, but you can see
 /// here that you can tweak details.
-use cd_da_reader::{CdReader, RetryConfig};
+use cd_da_reader::{CdReader, ReadOptions, RetryConfig};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let reader = CdReader::open_default()?;
@@ -17,19 +17,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // More attempts, longer backoff, and sector reduction down to 1
     // for maximum resilience on scratched media.
-    let retry = RetryConfig {
-        max_attempts: 8,
-        initial_backoff_ms: 50,
-        max_backoff_ms: 1000,
-        reduce_chunk_on_retry: true,
-        min_sectors_per_read: 1,
+    let options = ReadOptions {
+        retry: RetryConfig {
+            max_attempts: 8,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 1000,
+            reduce_chunk_on_retry: true,
+            min_sectors_per_read: 1,
+        },
+        ..ReadOptions::default()
     };
 
     println!(
         "Reading track {} with aggressive retry...",
         first_audio.number
     );
-    let data = reader.read_track_with_retry(&toc, first_audio.number, &retry)?;
+    let data = reader.read_track_with_options(&toc, first_audio.number, &options)?;
 
     let wav = CdReader::create_wav(data);
     let filename = format!("track{:02}.wav", first_audio.number);

--- a/examples/play_audio_track.rs
+++ b/examples/play_audio_track.rs
@@ -16,7 +16,7 @@
 //! The WAV is written to the current directory and then handed to the platform's
 //! built-in player (`afplay` on macOS, `Media.SoundPlayer` on Windows). On other
 //! platforms it is saved and you are told how to play it yourself.
-use cd_da_reader::{CdReader, RetryConfig, SectorReadMode};
+use cd_da_reader::{CdReader, ReadOptions};
 
 /// CD-DA plays 75 sectors (each 2352 bytes) per second.
 const SECTORS_PER_SECOND: u32 = 75;
@@ -53,12 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Reading first {actual_seconds}s ({sectors} sectors) of audio track #{}...",
         track.number
     );
-    let pcm = reader.read_data_sectors(
-        track.start_lba,
-        sectors,
-        SectorReadMode::Audio,
-        &RetryConfig::default(),
-    )?;
+    let pcm = reader.read_sector_range(track.start_lba, sectors, &ReadOptions::default())?;
     println!(
         "Read {} bytes of PCM ({:.1} MiB)",
         pcm.len(),

--- a/examples/read_data_track.rs
+++ b/examples/read_data_track.rs
@@ -9,7 +9,7 @@
 ///      Volume Descriptor — type byte `0x01` followed by `"CD001"`.
 ///   3. Cooked vs raw: the cooked 2048 B must equal the user-data region of
 ///      the raw sector (offset 16 for Mode 1).
-use cd_da_reader::{CdReader, RetryConfig, SectorReadMode};
+use cd_da_reader::{CdReader, ReadOptions, SectorReadMode};
 
 // ISO 9660 places the Primary Volume Descriptor at logical sector 16.
 const PVD_SECTOR_OFFSET: u32 = 16;
@@ -30,10 +30,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         data_track.number, data_track.start_lba, pvd_lba
     );
 
-    let cfg = RetryConfig::default();
+    let mut options = ReadOptions {
+        mode: SectorReadMode::DataRaw,
+        ..ReadOptions::default()
+    };
 
     // --- raw read (2352 B) -------------------------------------------------
-    let raw = reader.read_data_sectors(pvd_lba, 1, SectorReadMode::DataRaw, &cfg)?;
+    let raw = reader.read_sector_range(pvd_lba, 1, &options)?;
     if raw.len() != 2352 {
         return Err(format!("raw read returned {} bytes, expected 2352", raw.len()).into());
     }
@@ -58,7 +61,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- cooked read (2048 B) ---------------------------------------------
     // Our cooked mode maps to Mode 1; only meaningful to cross-check there.
     if mode == 1 {
-        let cooked = reader.read_data_sectors(pvd_lba, 1, SectorReadMode::DataCooked, &cfg)?;
+        options.mode = SectorReadMode::DataCooked;
+        let cooked = reader.read_sector_range(pvd_lba, 1, &options)?;
         if cooked.len() != 2048 {
             return Err(
                 format!("cooked read returned {} bytes, expected 2048", cooked.len()).into(),

--- a/src/data_reader.rs
+++ b/src/data_reader.rs
@@ -1,3 +1,23 @@
+use crate::retry::RetryConfig;
+
+/// Options for reading a complete track.
+#[derive(Debug, Clone)]
+pub struct ReadOptions {
+    /// Sector format requested from the drive.
+    pub mode: SectorReadMode,
+    /// Retry policy applied to each read command.
+    pub retry: RetryConfig,
+}
+
+impl Default for ReadOptions {
+    fn default() -> Self {
+        Self {
+            mode: SectorReadMode::Audio,
+            retry: RetryConfig::default(),
+        }
+    }
+}
+
 /// Sector read mode for the READ CD (0xBE) command.
 ///
 /// Controls CDB byte 1 (Expected Sector Type) and byte 9 (Main Channel Selection)
@@ -81,7 +101,14 @@ pub(crate) fn build_read_cd_cdb(lba: u32, sectors: u32, mode: SectorReadMode) ->
 
 #[cfg(test)]
 mod tests {
-    use super::{SectorReadMode, build_read_cd_cdb};
+    use super::{ReadOptions, SectorReadMode, build_read_cd_cdb};
+
+    #[test]
+    fn read_options_default_to_audio() {
+        let options = ReadOptions::default();
+
+        assert_eq!(options.mode, SectorReadMode::Audio);
+    }
 
     #[test]
     fn cdb_byte1_encodes_expected_sector_type() {

--- a/src/data_reader.rs
+++ b/src/data_reader.rs
@@ -69,7 +69,7 @@ impl SectorReadMode {
     /// Maximum sectors per single `READ CD` command.
     ///
     /// This is the sole chunker for the blocking `read_track` /
-    /// `read_data_sectors` paths, which hand a whole track (tens of thousands
+    /// `read_sector_range` paths, which can hand a whole track (tens of thousands
     /// of sectors) straight to the read loop; the streaming API already limits
     /// itself via `TrackStreamConfig::sectors_per_chunk`. The cap is not about
     /// OS pass-through limits (modern SG_IO/SPTI handle far larger transfers)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,33 +260,28 @@ impl CdReader {
     ) -> Result<Vec<u8>, CdReaderError> {
         let (start_lba, sectors) =
             utils::get_track_bounds(toc, track_no).map_err(CdReaderError::Io)?;
-        self.read_sector_range_with_retry(start_lba, sectors, options.mode, &options.retry)
+        self.read_sector_range(start_lba, sectors, options)
     }
 
-    /// Read sectors in a specific mode (audio, data cooked, or data raw).
+    /// Read an arbitrary range of sectors using explicit format and retry options.
     ///
-    /// This uses the READ CD (0xBE) SCSI command with configurable sector type
-    /// and main channel flags, supporting audio, cooked data (2048 B/sector),
-    /// and raw data (2352 B/sector) reads.
-    pub fn read_data_sectors(
-        &self,
-        lba: u32,
-        count: u32,
-        mode: SectorReadMode,
-        cfg: &RetryConfig,
-    ) -> Result<Vec<u8>, CdReaderError> {
-        self.read_sector_range_with_retry(lba, count, mode, cfg)
-    }
-
-    pub(crate) fn read_sector_range_with_retry(
+    /// # Low-level API
+    ///
+    /// Callers are responsible for providing valid sector boundaries and selecting
+    /// a format compatible with the sectors on the disc. Prefer [`CdReader::read_track`]
+    /// or [`CdReader::read_track_with_options`] when reading a complete TOC track.
+    pub fn read_sector_range(
         &self,
         start_lba: u32,
         sectors: u32,
-        mode: SectorReadMode,
-        cfg: &RetryConfig,
+        options: &ReadOptions,
     ) -> Result<Vec<u8>, CdReaderError> {
-        read_loop::read_sectors_chunked(start_lba, sectors, mode, cfg, |lba, chunk_sectors| {
-            self.drive.read_cd_chunk(lba, chunk_sectors, mode)
-        })
+        read_loop::read_sectors_chunked(
+            start_lba,
+            sectors,
+            options.mode,
+            &options.retry,
+            |lba, chunk_sectors| self.drive.read_cd_chunk(lba, chunk_sectors, options.mode),
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ mod read_loop;
 mod retry;
 mod stream;
 mod utils;
-pub use data_reader::SectorReadMode;
+pub use data_reader::{ReadOptions, SectorReadMode};
 pub use discovery::DriveInfo;
 pub use errors::{CdReaderError, ScsiError, ScsiOp};
 pub use retry::RetryConfig;
@@ -243,24 +243,24 @@ impl CdReader {
         self.drive.read_toc()
     }
 
-    /// Read raw data for the specified track number from the TOC.
+    /// Read an audio track using the default options.
+    ///
     /// It returns raw PCM data, but if you want to save it directly and make it playable,
-    /// wrap the result with `create_wav` function, that will prepend a RIFF header and
-    /// make it a proper music file.
+    /// wrap the result with [`CdReader::create_wav`].
     pub fn read_track(&self, toc: &Toc, track_no: u8) -> Result<Vec<u8>, CdReaderError> {
-        self.read_track_with_retry(toc, track_no, &RetryConfig::default())
+        self.read_track_with_options(toc, track_no, &ReadOptions::default())
     }
 
-    /// Read raw data for the specified track number from the TOC using explicit retry config.
-    pub fn read_track_with_retry(
+    /// Read a complete track using explicit sector-format and retry options.
+    pub fn read_track_with_options(
         &self,
         toc: &Toc,
         track_no: u8,
-        cfg: &RetryConfig,
+        options: &ReadOptions,
     ) -> Result<Vec<u8>, CdReaderError> {
         let (start_lba, sectors) =
             utils::get_track_bounds(toc, track_no).map_err(CdReaderError::Io)?;
-        self.read_sector_range_with_retry(start_lba, sectors, SectorReadMode::Audio, cfg)
+        self.read_sector_range_with_retry(start_lba, sectors, options.mode, &options.retry)
     }
 
     /// Read sectors in a specific mode (audio, data cooked, or data raw).

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 
-use crate::{CdReader, CdReaderError, RetryConfig, SectorReadMode, Toc, utils};
+use crate::{CdReader, CdReaderError, ReadOptions, RetryConfig, SectorReadMode, Toc, utils};
 
 /// Configuration for streamed track reads.
 #[derive(Debug, Clone)]
@@ -46,8 +46,11 @@ impl<'a> TrackStream<'a> {
     /// Returns `Ok(None)` when end-of-track is reached.
     pub fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, CdReaderError> {
         self.next_chunk_with(|lba, sectors, retry| {
-            self.reader
-                .read_sector_range_with_retry(lba, sectors, SectorReadMode::Audio, retry)
+            let options = ReadOptions {
+                mode: SectorReadMode::Audio,
+                retry: retry.clone(),
+            };
+            self.reader.read_sector_range(lba, sectors, &options)
         })
     }
 


### PR DESCRIPTION
## Description

Update reading API:

- defaults to audio track and default retry config
- rename the `with_retry` to `read_track_with_options` where you can specify which mode you want to use
- raw sector access is renamed to `read_sector_range` and added some inline doc that it is a low-level function and you probably want to use `read_track` or `read_track_with_options`

I think it is a bit more clear this way.