### PR TITLE
add open_track_stream_with_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,12 @@ let data = reader.read_track(&toc, 1)?;
 This is a blocking call and takes a lot of time (depends on the track length and CD/drive quality due to retries). If you want to do something with the data as it comes, use streaming API:
 
 ```rust
-use cd_da_reader::{CdReader, TrackStreamOptions};
+use cd_da_reader::CdReader;
 
 let reader = CdReader::open_default()?;
 let toc = reader.read_toc()?;
 
-let options = TrackStreamOptions::default();
-
-let mut stream = reader.open_track_stream(&toc, 1, options)?;
+let mut stream = reader.open_track_stream(&toc, 1)?;
 while let Some(chunk) = stream.next_chunk()? {
     // do something with the chunk directly
 }

--- a/examples/stream_last_track.rs
+++ b/examples/stream_last_track.rs
@@ -1,5 +1,5 @@
 /// Reads the last audio track using the streaming API and saves it as a WAV file.
-use cd_da_reader::{CdReader, TrackStreamOptions};
+use cd_da_reader::CdReader;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let reader = CdReader::open_default()?;
@@ -13,8 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("no audio tracks found")?;
 
     println!("Streaming track {}...", last_audio.number);
-    let mut stream =
-        reader.open_track_stream(&toc, last_audio.number, TrackStreamOptions::default())?;
+    let mut stream = reader.open_track_stream(&toc, last_audio.number)?;
 
     let mut pcm = Vec::new();
     while let Some(chunk) = stream.next_chunk()? {

--- a/examples/stream_with_progress.rs
+++ b/examples/stream_with_progress.rs
@@ -1,5 +1,5 @@
 /// Streams the first audio track while printing a live progress line.
-use cd_da_reader::{CdReader, TrackStreamOptions};
+use cd_da_reader::CdReader;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let reader = CdReader::open_default()?;
@@ -11,8 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .find(|t| t.is_audio)
         .ok_or("no audio tracks found")?;
 
-    let mut stream =
-        reader.open_track_stream(&toc, first_audio.number, TrackStreamOptions::default())?;
+    let mut stream = reader.open_track_stream(&toc, first_audio.number)?;
 
     let total_secs = stream.total_seconds();
     println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,14 +85,12 @@
 //! use the streaming API instead:
 //!
 //! ```no_run
-//! use cd_da_reader::{CdReader, TrackStreamOptions};
+//! use cd_da_reader::CdReader;
 //!
 //! let reader = CdReader::open_default()?;
 //! let toc = reader.read_toc()?;
 //!
-//! let options = TrackStreamOptions::default();
-//!
-//! let mut stream = reader.open_track_stream(&toc, 1, options)?;
+//! let mut stream = reader.open_track_stream(&toc, 1)?;
 //! while let Some(chunk) = stream.next_chunk()? {
 //!     // process chunk — raw PCM, 2 352 bytes per sector
 //! }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -161,13 +161,20 @@ impl<'a> TrackStream<'a> {
 }
 
 impl CdReader {
-    /// Open a streaming reader for a specific track in the provided TOC.
-    /// It is important to create track streams through this method so the
-    /// drive session is managed through a single CDReader instance.
+    /// Open a streaming reader for an audio track using the default options.
+    pub fn open_track_stream<'a>(
+        &'a self,
+        toc: &Toc,
+        track_no: u8,
+    ) -> Result<TrackStream<'a>, CdReaderError> {
+        self.open_track_stream_with_options(toc, track_no, TrackStreamOptions::default())
+    }
+
+    /// Open a streaming reader using explicit sector-format, retry, and chunk options.
     ///
     /// Use [`TrackStream::next_chunk`] to pull sector-aligned chunks in the
     /// format selected in [`TrackStreamOptions`].
-    pub fn open_track_stream<'a>(
+    pub fn open_track_stream_with_options<'a>(
         &'a self,
         toc: &Toc,
         track_no: u8,


### PR DESCRIPTION
## Description

As I mentioned in https://github.com/Bloomca/rust-cd-da-reader/pull/45, I think it is actually a great idea to match the `read_track` and `read_track_with_options` APIs. This solves the problem that the configuration is pretty verbose, and _most_ of the time I assume the consumers will simply need the audio track API.