### PR TITLE
rename SectorReadMode to SectorReadFormat

### DIFF
--- a/examples/read_data_track.rs
+++ b/examples/read_data_track.rs
@@ -9,7 +9,7 @@
 ///      Volume Descriptor — type byte `0x01` followed by `"CD001"`.
 ///   3. Cooked vs raw: the cooked 2048 B must equal the user-data region of
 ///      the raw sector (offset 16 for Mode 1).
-use cd_da_reader::{CdReader, ReadOptions, SectorReadMode};
+use cd_da_reader::{CdReader, ReadOptions, SectorReadFormat};
 
 // ISO 9660 places the Primary Volume Descriptor at logical sector 16.
 const PVD_SECTOR_OFFSET: u32 = 16;
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         data_track.number, data_track.start_lba, pvd_lba
     );
 
-    let mut options = ReadOptions::default().with_mode(SectorReadMode::DataRaw);
+    let mut options = ReadOptions::default().with_format(SectorReadFormat::Mode1Raw);
 
     // --- raw read (2352 B) -------------------------------------------------
     let raw = reader.read_sector_range(pvd_lba, 1, &options)?;
@@ -56,9 +56,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("ISO 9660 'CD001' : {}", pass(iso_ok));
 
     // --- cooked read (2048 B) ---------------------------------------------
-    // Our cooked mode maps to Mode 1; only meaningful to cross-check there.
+    // The cooked format is specifically Mode 1, so only cross-check it there.
     if mode == 1 {
-        options = options.with_mode(SectorReadMode::DataCooked);
+        options = options.with_format(SectorReadFormat::Mode1Cooked);
         let cooked = reader.read_sector_range(pvd_lba, 1, &options)?;
         if cooked.len() != 2048 {
             return Err(

--- a/src/data_reader.rs
+++ b/src/data_reader.rs
@@ -6,14 +6,14 @@ use crate::retry::RetryConfig;
 /// builder methods to override only the options you need.
 #[derive(Debug, Clone)]
 pub struct ReadOptions {
-    mode: SectorReadMode,
+    format: SectorReadFormat,
     retry: RetryConfig,
 }
 
 impl ReadOptions {
     /// Select the sector format requested from the drive.
-    pub fn with_mode(mut self, mode: SectorReadMode) -> Self {
-        self.mode = mode;
+    pub fn with_format(mut self, format: SectorReadFormat) -> Self {
+        self.format = format;
         self
     }
 
@@ -23,8 +23,8 @@ impl ReadOptions {
         self
     }
 
-    pub(crate) fn mode(&self) -> SectorReadMode {
-        self.mode
+    pub(crate) fn format(&self) -> SectorReadFormat {
+        self.format
     }
 
     pub(crate) fn retry(&self) -> &RetryConfig {
@@ -35,36 +35,36 @@ impl ReadOptions {
 impl Default for ReadOptions {
     fn default() -> Self {
         Self {
-            mode: SectorReadMode::Audio,
+            format: SectorReadFormat::Audio,
             retry: RetryConfig::default(),
         }
     }
 }
 
-/// Sector read mode for the READ CD (0xBE) command.
+/// Sector format requested through the READ CD (0xBE) command.
 ///
 /// Controls CDB byte 1 (Expected Sector Type) and byte 9 (Main Channel Selection)
-/// to read different sector formats from the same READ CD command.
+/// to return audio, cooked Mode 1 data, or complete Mode 1 sectors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SectorReadMode {
+pub enum SectorReadFormat {
     /// Audio: 2352 bytes/sector, raw PCM.
     /// CDB byte 1 = 0x00 (any type), byte 9 = 0x10 (user data).
     Audio,
-    /// Data cooked: 2048 bytes/sector, user data only (no sync/header/EDC/ECC).
+    /// Mode 1 cooked data: 2048 bytes/sector, containing user data only.
     /// CDB byte 1 = 0x08 (Mode 1), byte 9 = 0x10 (user data).
-    DataCooked,
-    /// Data raw: 2352 bytes/sector with sync + header + user data + EDC/ECC.
-    /// CDB byte 1 = 0x08 (Mode 1), byte 9 = 0xF8 (sync + header + user data + EDC/ECC).
-    DataRaw,
+    Mode1Cooked,
+    /// Complete Mode 1 sector: 2352 bytes with sync, header, user data, EDC, and ECC.
+    /// CDB byte 1 = 0x08 (Mode 1), byte 9 = 0xF8 (all main-channel fields).
+    Mode1Raw,
 }
 
-impl SectorReadMode {
-    /// Bytes per sector for this read mode.
+impl SectorReadFormat {
+    /// Bytes per sector for this read format.
     pub fn sector_size(&self) -> usize {
         match self {
-            SectorReadMode::Audio => 2352,
-            SectorReadMode::DataCooked => 2048,
-            SectorReadMode::DataRaw => 2352,
+            SectorReadFormat::Audio => 2352,
+            SectorReadFormat::Mode1Cooked => 2048,
+            SectorReadFormat::Mode1Raw => 2352,
         }
     }
 
@@ -74,18 +74,18 @@ impl SectorReadMode {
     /// `010b << 2 = 0x08`. (`0x04` would be `001b << 2`, i.e. CD-DA.)
     pub fn cdb_byte1(&self) -> u8 {
         match self {
-            SectorReadMode::Audio => 0x00,
-            SectorReadMode::DataCooked => 0x08,
-            SectorReadMode::DataRaw => 0x08,
+            SectorReadFormat::Audio => 0x00,
+            SectorReadFormat::Mode1Cooked => 0x08,
+            SectorReadFormat::Mode1Raw => 0x08,
         }
     }
 
     /// CDB byte 9: Main Channel Selection bits.
     pub fn cdb_byte9(&self) -> u8 {
         match self {
-            SectorReadMode::Audio => 0x10,
-            SectorReadMode::DataCooked => 0x10,
-            SectorReadMode::DataRaw => 0xF8,
+            SectorReadFormat::Audio => 0x10,
+            SectorReadFormat::Mode1Cooked => 0x10,
+            SectorReadFormat::Mode1Raw => 0xF8,
         }
     }
 
@@ -110,63 +110,63 @@ impl SectorReadMode {
 
 /// Build a READ CD (0xBE) command descriptor block for Linux and Windows.
 #[cfg(any(target_os = "linux", target_os = "windows", test))]
-pub(crate) fn build_read_cd_cdb(lba: u32, sectors: u32, mode: SectorReadMode) -> [u8; 12] {
+pub(crate) fn build_read_cd_cdb(lba: u32, sectors: u32, format: SectorReadFormat) -> [u8; 12] {
     let mut cdb = [0u8; 12];
     cdb[0] = 0xBE;
-    cdb[1] = mode.cdb_byte1();
+    cdb[1] = format.cdb_byte1();
     cdb[2..6].copy_from_slice(&lba.to_be_bytes());
     cdb[6] = ((sectors >> 16) & 0xFF) as u8;
     cdb[7] = ((sectors >> 8) & 0xFF) as u8;
     cdb[8] = (sectors & 0xFF) as u8;
-    cdb[9] = mode.cdb_byte9();
+    cdb[9] = format.cdb_byte9();
     cdb
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ReadOptions, SectorReadMode, build_read_cd_cdb};
+    use super::{ReadOptions, SectorReadFormat, build_read_cd_cdb};
 
     #[test]
     fn read_options_builders_override_individual_defaults() {
-        assert_eq!(ReadOptions::default().mode(), SectorReadMode::Audio);
+        assert_eq!(ReadOptions::default().format(), SectorReadFormat::Audio);
 
         let retry = crate::RetryConfig::default().with_max_attempts(9);
         let options = ReadOptions::default()
-            .with_mode(SectorReadMode::DataRaw)
+            .with_format(SectorReadFormat::Mode1Raw)
             .with_retry(retry);
 
-        assert_eq!(options.mode(), SectorReadMode::DataRaw);
+        assert_eq!(options.format(), SectorReadFormat::Mode1Raw);
         assert_eq!(options.retry().max_attempts, 9);
     }
 
     #[test]
     fn cdb_byte1_encodes_expected_sector_type() {
         // Expected Sector Type lives in CDB byte 1, bits 4-2 (value << 2).
-        // Audio leaves it 0 (any type) and relies on byte 9; data reads must
-        // select Mode 1 = 010b << 2 = 0x08 (0x04 would wrongly mean CD-DA).
-        assert_eq!(SectorReadMode::Audio.cdb_byte1(), 0x00);
-        assert_eq!(SectorReadMode::DataCooked.cdb_byte1(), 0x08);
-        assert_eq!(SectorReadMode::DataRaw.cdb_byte1(), 0x08);
+        // Audio leaves it 0 (any type) and relies on byte 9; Mode 1 reads use
+        // 010b << 2 = 0x08 (0x04 would mean CD-DA).
+        assert_eq!(SectorReadFormat::Audio.cdb_byte1(), 0x00);
+        assert_eq!(SectorReadFormat::Mode1Cooked.cdb_byte1(), 0x08);
+        assert_eq!(SectorReadFormat::Mode1Raw.cdb_byte1(), 0x08);
     }
 
     #[test]
     fn cdb_byte9_selects_main_channel() {
-        assert_eq!(SectorReadMode::Audio.cdb_byte9(), 0x10);
-        assert_eq!(SectorReadMode::DataCooked.cdb_byte9(), 0x10);
-        assert_eq!(SectorReadMode::DataRaw.cdb_byte9(), 0xF8);
+        assert_eq!(SectorReadFormat::Audio.cdb_byte9(), 0x10);
+        assert_eq!(SectorReadFormat::Mode1Cooked.cdb_byte9(), 0x10);
+        assert_eq!(SectorReadFormat::Mode1Raw.cdb_byte9(), 0xF8);
     }
 
     #[test]
-    fn sector_size_matches_mode() {
-        assert_eq!(SectorReadMode::Audio.sector_size(), 2352);
-        assert_eq!(SectorReadMode::DataCooked.sector_size(), 2048);
-        assert_eq!(SectorReadMode::DataRaw.sector_size(), 2352);
+    fn sector_size_matches_format() {
+        assert_eq!(SectorReadFormat::Audio.sector_size(), 2352);
+        assert_eq!(SectorReadFormat::Mode1Cooked.sector_size(), 2048);
+        assert_eq!(SectorReadFormat::Mode1Raw.sector_size(), 2352);
     }
 
     #[test]
     fn builds_read_cd_cdb() {
         assert_eq!(
-            build_read_cd_cdb(0x1234_5678, 0x0000_ABCD, SectorReadMode::DataRaw),
+            build_read_cd_cdb(0x1234_5678, 0x0000_ABCD, SectorReadFormat::Mode1Raw),
             [
                 0xBE, 0x08, 0x12, 0x34, 0x56, 0x78, 0x00, 0xAB, 0xCD, 0xF8, 0x00, 0x00,
             ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ mod read_loop;
 mod retry;
 mod stream;
 mod utils;
-pub use data_reader::{ReadOptions, SectorReadMode};
+pub use data_reader::{ReadOptions, SectorReadFormat};
 pub use discovery::DriveInfo;
 pub use errors::{CdReaderError, ScsiError, ScsiOp};
 pub use retry::RetryConfig;
@@ -271,13 +271,13 @@ impl CdReader {
         sectors: u32,
         options: &ReadOptions,
     ) -> Result<Vec<u8>, CdReaderError> {
-        let mode = options.mode();
+        let format = options.format();
         read_loop::read_sectors_chunked(
             start_lba,
             sectors,
-            mode,
+            format,
             options.retry(),
-            |lba, chunk_sectors| self.drive.read_cd_chunk(lba, chunk_sectors, mode),
+            |lba, chunk_sectors| self.drive.read_cd_chunk(lba, chunk_sectors, format),
         )
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -5,7 +5,7 @@ mod toc;
 
 pub(crate) use device::{Drive, list_drive_paths};
 
-use crate::{CdReaderError, SectorReadMode, Toc};
+use crate::{CdReaderError, SectorReadFormat, Toc};
 
 impl Drive {
     pub(crate) fn read_toc(&self) -> Result<Toc, CdReaderError> {
@@ -16,8 +16,8 @@ impl Drive {
         &self,
         lba: u32,
         sectors: u32,
-        mode: SectorReadMode,
+        format: SectorReadFormat,
     ) -> Result<Vec<u8>, CdReaderError> {
-        read_cd::read_cd_chunk(self, lba, sectors, mode)
+        read_cd::read_cd_chunk(self, lba, sectors, format)
     }
 }

--- a/src/platform/linux/read_cd.rs
+++ b/src/platform/linux/read_cd.rs
@@ -1,6 +1,6 @@
 use super::device::Drive;
 use super::sg_io::{CommandContext, execute_read};
-use crate::data_reader::{SectorReadMode, build_read_cd_cdb};
+use crate::data_reader::{SectorReadFormat, build_read_cd_cdb};
 use crate::{CdReaderError, ScsiOp};
 
 const READ_CD_TIMEOUT_MS: u32 = 30_000;
@@ -9,10 +9,10 @@ pub(super) fn read_cd_chunk(
     drive: &Drive,
     lba: u32,
     sectors: u32,
-    mode: SectorReadMode,
+    format: SectorReadFormat,
 ) -> Result<Vec<u8>, CdReaderError> {
-    let mut chunk = vec![0u8; sectors as usize * mode.sector_size()];
-    let mut cdb = build_read_cd_cdb(lba, sectors, mode);
+    let mut chunk = vec![0u8; sectors as usize * format.sector_size()];
+    let mut cdb = build_read_cd_cdb(lba, sectors, format);
     let transferred = execute_read(
         drive.fd(),
         &mut cdb,

--- a/src/platform/macos/ffi.rs
+++ b/src/platform/macos/ffi.rs
@@ -31,7 +31,7 @@ unsafe extern "C" {
         fd: libc::c_int,
         lba: u32,
         sectors: u32,
-        mode_id: u32,
+        format_id: u32,
         out_buf: *mut *mut u8,
         out_len: *mut u32,
         out_err: *mut MacScsiError,

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -5,7 +5,7 @@ mod toc;
 
 pub(crate) use device::{Drive, list_drive_paths};
 
-use crate::{CdReaderError, SectorReadMode, Toc};
+use crate::{CdReaderError, SectorReadFormat, Toc};
 
 impl Drive {
     pub(crate) fn read_toc(&self) -> Result<Toc, CdReaderError> {
@@ -16,8 +16,8 @@ impl Drive {
         &self,
         lba: u32,
         sectors: u32,
-        mode: SectorReadMode,
+        format: SectorReadFormat,
     ) -> Result<Vec<u8>, CdReaderError> {
-        read_cd::read_cd_chunk(self, lba, sectors, mode)
+        read_cd::read_cd_chunk(self, lba, sectors, format)
     }
 }

--- a/src/platform/macos/native/read_cd.c
+++ b/src/platform/macos/native/read_cd.c
@@ -1,17 +1,18 @@
 #include "shim_common.h"
 
-// Map our SectorReadMode discriminant to the macOS CD sector area/type and the
-// resulting bytes-per-sector. Keeping the mapping here (rather than in Rust)
-// means the IOKit constants only ever appear where their header is imported.
+// Map our SectorReadFormat discriminant to the macOS CD sector area/type and
+// the resulting bytes-per-sector. Keeping the mapping here (rather than in
+// Rust) means the IOKit constants only ever appear where their header is
+// imported.
 //
-//   0 = Audio       -> user area, CDDA,  2352 B/sector
-//   1 = DataCooked  -> user area, Mode 1, 2048 B/sector
-//   2 = DataRaw     -> sync+header+user+aux, Mode 1, 2352 B/sector
-static bool sector_layout_for_mode(uint32_t mode_id,
+//   0 = Audio        -> user area, CDDA,  2352 B/sector
+//   1 = Mode1Cooked  -> user area, Mode 1, 2048 B/sector
+//   2 = Mode1Raw     -> sync+header+user+aux, Mode 1, 2352 B/sector
+static bool sector_layout_for_format(uint32_t format_id,
                                    CDSectorArea *outArea,
                                    CDSectorType *outType,
                                    uint32_t *outSectorSize) {
-    switch (mode_id) {
+    switch (format_id) {
         case 0:
             *outArea = kCDSectorAreaUser;
             *outType = kCDSectorTypeCDDA;
@@ -33,7 +34,7 @@ static bool sector_layout_for_mode(uint32_t mode_id,
     }
 }
 
-bool read_cd_sectors(int fd, uint32_t lba, uint32_t sectors, uint32_t mode_id,
+bool read_cd_sectors(int fd, uint32_t lba, uint32_t sectors, uint32_t format_id,
                      uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr) {
     *outBuf = NULL;
     *outLen = 0;
@@ -44,8 +45,8 @@ bool read_cd_sectors(int fd, uint32_t lba, uint32_t sectors, uint32_t mode_id,
     CDSectorArea sectorArea;
     CDSectorType sectorType;
     uint32_t sectorSize;
-    if (!sector_layout_for_mode(mode_id, &sectorArea, &sectorType, &sectorSize)) {
-        fprintf(stderr, "[READ] unknown sector mode %u\n", mode_id);
+    if (!sector_layout_for_format(format_id, &sectorArea, &sectorType, &sectorSize)) {
+        fprintf(stderr, "[READ] unknown sector format %u\n", format_id);
         goto fail;
     }
 

--- a/src/platform/macos/native/shim_common.h
+++ b/src/platform/macos/native/shim_common.h
@@ -33,7 +33,7 @@ typedef struct {
 } CdDriveInfo;
 
 bool cd_read_toc(int fd, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);
-bool read_cd_sectors(int fd, uint32_t lba, uint32_t sectors, uint32_t mode_id, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);
+bool read_cd_sectors(int fd, uint32_t lba, uint32_t sectors, uint32_t format_id, uint8_t **outBuf, uint32_t *outLen, CdScsiError *outErr);
 void cd_free(void *p);
 
 bool list_cd_drives(CdDriveInfo **outDrives, uint32_t *outCount);

--- a/src/platform/macos/read_cd.rs
+++ b/src/platform/macos/read_cd.rs
@@ -2,13 +2,13 @@ use std::{ptr, slice};
 
 use super::device::Drive;
 use super::ffi::{MacScsiError, cd_free, map_error, read_cd_sectors};
-use crate::{CdReaderError, ScsiOp, SectorReadMode};
+use crate::{CdReaderError, ScsiOp, SectorReadFormat};
 
 pub(super) fn read_cd_chunk(
     drive: &Drive,
     lba: u32,
     sectors: u32,
-    mode: SectorReadMode,
+    format: SectorReadFormat,
 ) -> Result<Vec<u8>, CdReaderError> {
     let mut buffer: *mut u8 = ptr::null_mut();
     let mut len = 0u32;
@@ -19,7 +19,7 @@ pub(super) fn read_cd_chunk(
             drive.fd(),
             lba,
             sectors,
-            mode_id(mode),
+            format_id(format),
             &mut buffer,
             &mut len,
             &mut error,
@@ -36,23 +36,23 @@ pub(super) fn read_cd_chunk(
 }
 
 // Discriminant understood by the native `read_cd_sectors` implementation.
-fn mode_id(mode: SectorReadMode) -> u32 {
-    match mode {
-        SectorReadMode::Audio => 0,
-        SectorReadMode::DataCooked => 1,
-        SectorReadMode::DataRaw => 2,
+fn format_id(format: SectorReadFormat) -> u32 {
+    match format {
+        SectorReadFormat::Audio => 0,
+        SectorReadFormat::Mode1Cooked => 1,
+        SectorReadFormat::Mode1Raw => 2,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::mode_id;
-    use crate::SectorReadMode;
+    use super::format_id;
+    use crate::SectorReadFormat;
 
     #[test]
-    fn maps_sector_modes_to_native_ids() {
-        assert_eq!(mode_id(SectorReadMode::Audio), 0);
-        assert_eq!(mode_id(SectorReadMode::DataCooked), 1);
-        assert_eq!(mode_id(SectorReadMode::DataRaw), 2);
+    fn maps_sector_formats_to_native_ids() {
+        assert_eq!(format_id(SectorReadFormat::Audio), 0);
+        assert_eq!(format_id(SectorReadFormat::Mode1Cooked), 1);
+        assert_eq!(format_id(SectorReadFormat::Mode1Raw), 2);
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -5,7 +5,7 @@ mod toc;
 
 pub(crate) use device::{Drive, list_drive_paths};
 
-use crate::{CdReaderError, SectorReadMode, Toc};
+use crate::{CdReaderError, SectorReadFormat, Toc};
 
 impl Drive {
     pub(crate) fn read_toc(&self) -> Result<Toc, CdReaderError> {
@@ -16,8 +16,8 @@ impl Drive {
         &self,
         lba: u32,
         sectors: u32,
-        mode: SectorReadMode,
+        format: SectorReadFormat,
     ) -> Result<Vec<u8>, CdReaderError> {
-        read_cd::read_cd_chunk(self, lba, sectors, mode)
+        read_cd::read_cd_chunk(self, lba, sectors, format)
     }
 }

--- a/src/platform/windows/read_cd.rs
+++ b/src/platform/windows/read_cd.rs
@@ -1,6 +1,6 @@
 use super::device::Drive;
 use super::spti::{CommandContext, execute_read};
-use crate::data_reader::{SectorReadMode, build_read_cd_cdb};
+use crate::data_reader::{SectorReadFormat, build_read_cd_cdb};
 use crate::{CdReaderError, ScsiOp};
 
 const READ_CD_TIMEOUT_SECONDS: u32 = 30;
@@ -9,10 +9,10 @@ pub(super) fn read_cd_chunk(
     drive: &Drive,
     lba: u32,
     sectors: u32,
-    mode: SectorReadMode,
+    format: SectorReadFormat,
 ) -> Result<Vec<u8>, CdReaderError> {
-    let mut chunk = vec![0u8; sectors as usize * mode.sector_size()];
-    let cdb = build_read_cd_cdb(lba, sectors, mode);
+    let mut chunk = vec![0u8; sectors as usize * format.sector_size()];
+    let cdb = build_read_cd_cdb(lba, sectors, format);
     let transferred = execute_read(
         drive.handle(),
         &cdb,

--- a/src/read_loop.rs
+++ b/src/read_loop.rs
@@ -8,10 +8,10 @@
 
 use std::thread::sleep;
 
-use crate::data_reader::SectorReadMode;
+use crate::data_reader::SectorReadFormat;
 use crate::{CdReaderError, RetryConfig};
 
-/// Read `sectors` sectors starting at `start_lba` in the given `mode`.
+/// Read `sectors` sectors starting at `start_lba` in the given `format`.
 ///
 /// `read_chunk(lba, sectors)` performs one platform-specific `READ CD`
 /// command and returns the raw bytes for that chunk. The loop owns chunk
@@ -20,7 +20,7 @@ use crate::{CdReaderError, RetryConfig};
 pub(crate) fn read_sectors_chunked<F>(
     start_lba: u32,
     sectors: u32,
-    mode: SectorReadMode,
+    format: SectorReadFormat,
     cfg: &RetryConfig,
     mut read_chunk: F,
 ) -> Result<Vec<u8>, CdReaderError>
@@ -32,9 +32,9 @@ where
     }
 
     let total_bytes = (sectors as usize)
-        .checked_mul(mode.sector_size())
+        .checked_mul(format.sector_size())
         .ok_or_else(|| invalid_input("requested byte count is too large"))?;
-    let max_sectors_per_xfer = mode.max_sectors_per_xfer();
+    let max_sectors_per_xfer = format.max_sectors_per_xfer();
     let mut out = Vec::<u8>::new();
     out.try_reserve_exact(total_bytes)
         .map_err(|_| invalid_input("could not allocate the requested output buffer"))?;
@@ -51,7 +51,7 @@ where
 
         for attempt in 1..=attempts_total {
             let result = read_chunk(lba, chunk_sectors).and_then(|chunk| {
-                let expected_len = (chunk_sectors as usize) * mode.sector_size();
+                let expected_len = (chunk_sectors as usize) * format.sector_size();
                 if chunk.len() != expected_len {
                     return Err(CdReaderError::Io(std::io::Error::new(
                         std::io::ErrorKind::UnexpectedEof,
@@ -120,7 +120,7 @@ mod tests {
     use std::time::Duration;
 
     use super::read_sectors_chunked;
-    use crate::{CdReaderError, RetryConfig, SectorReadMode};
+    use crate::{CdReaderError, RetryConfig, SectorReadFormat};
 
     fn retry_config(max_attempts: u8, reduce_chunk_on_retry: bool) -> RetryConfig {
         RetryConfig::default()
@@ -136,7 +136,7 @@ mod tests {
         let data = read_sectors_chunked(
             100,
             60,
-            SectorReadMode::Audio,
+            SectorReadFormat::Audio,
             &retry_config(1, false),
             |lba, sectors| {
                 calls.push((lba, sectors));
@@ -156,7 +156,7 @@ mod tests {
         let data = read_sectors_chunked(
             100,
             10,
-            SectorReadMode::Audio,
+            SectorReadFormat::Audio,
             &retry_config(2, true),
             |lba, sectors| {
                 calls.push((lba, sectors));
@@ -181,7 +181,7 @@ mod tests {
         let data = read_sectors_chunked(
             200,
             2,
-            SectorReadMode::DataCooked,
+            SectorReadFormat::Mode1Cooked,
             &retry_config(2, false),
             |lba, sectors| {
                 calls.push((lba, sectors));
@@ -204,7 +204,7 @@ mod tests {
         let err = read_sectors_chunked(
             u32::MAX,
             2,
-            SectorReadMode::Audio,
+            SectorReadFormat::Audio,
             &retry_config(1, false),
             |_, _| {
                 called = true;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 
-use crate::{CdReader, CdReaderError, ReadOptions, RetryConfig, SectorReadMode, Toc, utils};
+use crate::{CdReader, CdReaderError, ReadOptions, RetryConfig, SectorReadFormat, Toc, utils};
 
 /// Options for streamed track reads.
 ///
@@ -9,14 +9,14 @@ use crate::{CdReader, CdReaderError, ReadOptions, RetryConfig, SectorReadMode, T
 #[derive(Debug, Clone)]
 pub struct TrackStreamOptions {
     sectors_per_chunk: u32,
-    mode: SectorReadMode,
+    format: SectorReadFormat,
     retry: RetryConfig,
 }
 
 impl TrackStreamOptions {
     /// Select the sector format requested from the drive.
-    pub fn with_mode(mut self, mode: SectorReadMode) -> Self {
-        self.mode = mode;
+    pub fn with_format(mut self, format: SectorReadFormat) -> Self {
+        self.format = format;
         self
     }
 
@@ -28,7 +28,7 @@ impl TrackStreamOptions {
 
     /// Set the target chunk size in sectors.
     ///
-    /// The byte size of a chunk also depends on [`SectorReadMode`]. A value of
+    /// The byte size of a chunk also depends on [`SectorReadFormat`]. A value of
     /// zero is normalized to one sector.
     pub fn with_sectors_per_chunk(mut self, sectors: u32) -> Self {
         self.sectors_per_chunk = sectors.max(1);
@@ -40,7 +40,7 @@ impl Default for TrackStreamOptions {
     fn default() -> Self {
         Self {
             sectors_per_chunk: 27,
-            mode: SectorReadMode::Audio,
+            format: SectorReadFormat::Audio,
             retry: RetryConfig::default(),
         }
     }
@@ -65,11 +65,11 @@ impl<'a> TrackStream<'a> {
     /// Read the next chunk of sector data.
     ///
     /// Returns `Ok(None)` when end-of-track is reached. The bytes per sector
-    /// depend on the [`SectorReadMode`] selected in [`TrackStreamOptions`].
+    /// depend on the [`SectorReadFormat`] selected in [`TrackStreamOptions`].
     pub fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, CdReaderError> {
-        self.next_chunk_with(|lba, sectors, mode, retry| {
+        self.next_chunk_with(|lba, sectors, format, retry| {
             let options = ReadOptions::default()
-                .with_mode(mode)
+                .with_format(format)
                 .with_retry(retry.clone());
             self.reader.read_sector_range(lba, sectors, &options)
         })
@@ -77,7 +77,7 @@ impl<'a> TrackStream<'a> {
 
     fn next_chunk_with<F>(&mut self, mut read_fn: F) -> Result<Option<Vec<u8>>, CdReaderError>
     where
-        F: FnMut(u32, u32, SectorReadMode, &RetryConfig) -> Result<Vec<u8>, CdReaderError>,
+        F: FnMut(u32, u32, SectorReadFormat, &RetryConfig) -> Result<Vec<u8>, CdReaderError>,
     {
         if self.remaining_sectors == 0 {
             return Ok(None);
@@ -87,7 +87,7 @@ impl<'a> TrackStream<'a> {
         let chunk = read_fn(
             self.next_lba,
             sectors,
-            self.options.mode,
+            self.options.format,
             &self.options.retry,
         )?;
 
@@ -196,7 +196,7 @@ impl CdReader {
 #[cfg(test)]
 mod tests {
     use super::{TrackStream, TrackStreamOptions};
-    use crate::{CdReader, CdReaderError, RetryConfig, SectorReadMode};
+    use crate::{CdReader, CdReaderError, RetryConfig, SectorReadFormat};
 
     fn mk_stream(
         start_lba: u32,
@@ -218,11 +218,11 @@ mod tests {
     fn options_builders_override_individual_defaults() {
         let retry = RetryConfig::default().with_max_attempts(9);
         let options = TrackStreamOptions::default()
-            .with_mode(SectorReadMode::DataRaw)
+            .with_format(SectorReadFormat::Mode1Raw)
             .with_retry(retry)
             .with_sectors_per_chunk(0);
 
-        assert_eq!(options.mode, SectorReadMode::DataRaw);
+        assert_eq!(options.format, SectorReadFormat::Mode1Raw);
         assert_eq!(options.retry.max_attempts, 9);
         assert_eq!(options.sectors_per_chunk, 1);
     }
@@ -269,18 +269,18 @@ mod tests {
     }
 
     #[test]
-    fn next_chunk_uses_configured_mode_and_advances() {
+    fn next_chunk_uses_configured_format_and_advances() {
         let mut stream = mk_stream(10_000, 100, 27);
-        stream.options = stream.options.with_mode(SectorReadMode::DataCooked);
+        stream.options = stream.options.with_format(SectorReadFormat::Mode1Cooked);
         let mut called = false;
 
         let chunk = stream
-            .next_chunk_with(|lba, sectors, mode, _| {
+            .next_chunk_with(|lba, sectors, format, _| {
                 called = true;
                 assert_eq!(lba, 10_000);
                 assert_eq!(sectors, 27);
-                assert_eq!(mode, SectorReadMode::DataCooked);
-                Ok(vec![0u8; (sectors as usize) * mode.sector_size()])
+                assert_eq!(format, SectorReadFormat::Mode1Cooked);
+                Ok(vec![0u8; (sectors as usize) * format.sector_size()])
             })
             .unwrap()
             .unwrap();


### PR DESCRIPTION
## Description

Rename the SectorReadMode into a more specific:

```rust
pub enum SectorReadFormat {
    /// Audio: 2352 bytes/sector, raw PCM.
    /// CDB byte 1 = 0x00 (any type), byte 9 = 0x10 (user data).
    Audio,
    /// Mode 1 cooked data: 2048 bytes/sector, containing user data only.
    /// CDB byte 1 = 0x08 (Mode 1), byte 9 = 0x10 (user data).
    Mode1Cooked,
    /// Complete Mode 1 sector: 2352 bytes with sync, header, user data, EDC, and ECC.
    /// CDB byte 1 = 0x08 (Mode 1), byte 9 = 0xF8 (all main-channel fields).
    Mode1Raw,
}
```