### PR TITLE
hide internal data reader API

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,8 +11,6 @@ pub enum ScsiOp {
     ReadCd,
     /// `READ TRACK INFORMATION` command (opcode `0x52`) for track metadata.
     ReadTrackInformation,
-    /// `READ SUB-CHANNEL` command for Q-channel/subcode metadata.
-    ReadSubChannel,
 }
 
 /// Structured SCSI failure context captured at the call site.
@@ -44,7 +42,7 @@ pub enum CdReaderError {
     Io(std::io::Error),
     /// Device reported a SCSI command failure with status/sense context.
     Scsi(ScsiError),
-    /// Parsing failure for command payloads (TOC/CD-TEXT/subchannel parsing).
+    /// Parsing failure for command response payloads.
     Parse(String),
     /// The requested sector format is incompatible with the track type.
     TrackFormatMismatch {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@
 //! [MusicBrainz disc ID algorithm]: https://musicbrainz.org/doc/Disc_ID_Calculation
 mod platform;
 
-pub mod data_reader;
+mod data_reader;
 mod discovery;
 mod errors;
 mod read_loop;

--- a/src/parse_toc.rs
+++ b/src/parse_toc.rs
@@ -1,6 +1,6 @@
 use crate::{Toc, Track};
 
-pub fn parse_toc(data: Vec<u8>) -> std::io::Result<Toc> {
+pub(crate) fn parse_toc(data: Vec<u8>) -> std::io::Result<Toc> {
     // TOC data format:
     // Bytes 0-1: TOC data length
     // Byte 2: First track number

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use crate::Toc;
 
 const CD_EXTRA_TRAILING_DATA_GAP_SECTORS: u32 = 11_400;
 
-pub fn get_track_bounds(toc: &Toc, track_no: u8) -> std::io::Result<(u32, u32)> {
+pub(crate) fn get_track_bounds(toc: &Toc, track_no: u8) -> std::io::Result<(u32, u32)> {
     let idx = toc
         .tracks
         .iter()
@@ -46,7 +46,7 @@ fn bad_toc_bounds() -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, "bad TOC bounds")
 }
 
-pub fn create_wav_header(pcm_data_size: u32) -> Vec<u8> {
+pub(crate) fn create_wav_header(pcm_data_size: u32) -> Vec<u8> {
     let mut header = Vec::with_capacity(44);
 
     // RIFF header


### PR DESCRIPTION
## Description

Hide internal DataReader APIs, removed unused SCSI command for subchannel (will add it back if we add support for it).