### PR TITLE
run CI on all platforms

### DIFF
--- a/.github/workflows/pull-request-workflow.yaml
+++ b/.github/workflows/pull-request-workflow.yaml
@@ -9,7 +9,12 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    name: Formatting, Clippy and Tests checks
+    strategy:
+      matrix:
+          os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Description

Run CI job on all platforms. It is not the strictest check but it should confirm that it compiles on every platform.

## Reference

Closes https://github.com/Bloomca/rust-cd-da-reader/issues/47