### PR TITLE
update examples to use target output directory

### DIFF
--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+
+pub fn fresh_output_dir(example: &str) -> std::io::Result<PathBuf> {
+    let directory = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("example-output")
+        .join(example);
+
+    if directory.exists() {
+        std::fs::remove_dir_all(&directory)?;
+    }
+    std::fs::create_dir_all(&directory)?;
+
+    println!("Output directory: {}", directory.display());
+    Ok(directory)
+}

--- a/examples/custom_retry.rs
+++ b/examples/custom_retry.rs
@@ -3,11 +3,14 @@
 /// By default, it already retries multiple times with smaller number
 /// of sectors, so this usually should not be necessary, but you can see
 /// here that you can tweak details.
+mod common;
+
 use std::time::Duration;
 
 use cd_da_reader::{CdReader, ReadOptions, RetryConfig};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output_dir = common::fresh_output_dir("custom_retry")?;
     let reader = CdReader::open_default()?;
     let toc = reader.read_toc()?;
 
@@ -34,9 +37,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data = reader.read_track_with_options(&toc, first_audio.number, &options)?;
 
     let wav = CdReader::create_wav(data);
-    let filename = format!("track{:02}.wav", first_audio.number);
-    std::fs::write(&filename, wav)?;
-    println!("Saved {}", filename);
+    let output_path = output_dir.join(format!("track{:02}.wav", first_audio.number));
+    std::fs::write(&output_path, wav)?;
+    println!("Saved {}", output_path.display());
 
     Ok(())
 }

--- a/examples/play_audio_track.rs
+++ b/examples/play_audio_track.rs
@@ -13,15 +13,20 @@
 //!   cargo run --example play_audio_track            # first 30 seconds
 //!   cargo run --example play_audio_track -- 60      # first 60 seconds
 //!
-//! The WAV is written to the current directory and then handed to the platform's
-//! built-in player (`afplay` on macOS, `Media.SoundPlayer` on Windows). On other
-//! platforms it is saved and you are told how to play it yourself.
+//! The WAV is written under `target/example-output` and then handed to the
+//! platform's built-in player (`afplay` on macOS, `Media.SoundPlayer` on
+//! Windows). On other platforms it is saved for playback with another player.
+mod common;
+
+use std::path::Path;
+
 use cd_da_reader::{CdReader, ReadOptions};
 
 /// CD-DA plays 75 sectors (each 2352 bytes) per second.
 const SECTORS_PER_SECOND: u32 = 75;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output_dir = common::fresh_output_dir("play_audio_track")?;
     let seconds: u32 = match std::env::args().nth(1) {
         Some(a) => a.parse()?,
         None => 30,
@@ -60,16 +65,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         pcm.len() as f64 / (1024.0 * 1024.0)
     );
 
-    let filename = format!("track{:02}_preview.wav", track.number);
-    std::fs::write(&filename, CdReader::create_wav(pcm))?;
-    println!("Saved {filename}");
+    let output_path = output_dir.join(format!("track{:02}_preview.wav", track.number));
+    std::fs::write(&output_path, CdReader::create_wav(pcm))?;
+    println!("Saved {}", output_path.display());
 
-    play(&filename)
+    play(&output_path)
 }
 
 /// Hand the WAV to the OS's built-in player and block until it finishes.
 #[cfg(target_os = "macos")]
-fn play(path: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn play(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     println!("Playing (Ctrl+C to stop)...");
     let status = std::process::Command::new("afplay").arg(path).status()?;
     if !status.success() {
@@ -79,10 +84,11 @@ fn play(path: &str) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(target_os = "windows")]
-fn play(path: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn play(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     println!("Playing (this blocks until the preview ends)...");
     // SoundPlayer.PlaySync plays a WAV synchronously using the built-in player.
-    let script = format!("(New-Object Media.SoundPlayer '{path}').PlaySync()");
+    let escaped_path = path.display().to_string().replace('\'', "''");
+    let script = format!("(New-Object Media.SoundPlayer '{escaped_path}').PlaySync()");
     let status = std::process::Command::new("powershell")
         .args(["-NoProfile", "-Command", &script])
         .status()?;
@@ -93,7 +99,10 @@ fn play(path: &str) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn play(path: &str) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Saved the WAV — play it with your audio player, e.g. `aplay {path}`.");
+fn play(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "Saved the WAV — play it with your audio player, e.g. `aplay {}`.",
+        path.display()
+    );
     Ok(())
 }

--- a/examples/read_all_tracks.rs
+++ b/examples/read_all_tracks.rs
@@ -1,7 +1,10 @@
 /// Reads every audio track from the default CD drive and saves each as a WAV file.
+mod common;
+
 use cd_da_reader::CdReader;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output_dir = common::fresh_output_dir("read_all_tracks")?;
     let reader = CdReader::open_default()?;
     let toc = reader.read_toc()?;
 
@@ -15,9 +18,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         match reader.read_track(&toc, track.number) {
             Ok(data) => {
                 let wav = CdReader::create_wav(data);
-                let filename = format!("track{:02}.wav", track.number);
-                std::fs::write(&filename, wav)?;
-                println!("saved {}", filename);
+                let output_path = output_dir.join(format!("track{:02}.wav", track.number));
+                std::fs::write(&output_path, wav)?;
+                println!("saved {}", output_path.display());
             }
             Err(e) => {
                 println!("FAILED: {}", e);

--- a/examples/read_first_track.rs
+++ b/examples/read_first_track.rs
@@ -1,7 +1,10 @@
 /// Reads the first audio track from the default CD drive and saves it as a WAV file.
+mod common;
+
 use cd_da_reader::CdReader;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output_dir = common::fresh_output_dir("read_first_track")?;
     let reader = CdReader::open_default()?;
     let toc = reader.read_toc()?;
 
@@ -15,9 +18,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data = reader.read_track(&toc, first_audio.number)?;
 
     let wav = CdReader::create_wav(data);
-    let filename = format!("track{:02}.wav", first_audio.number);
-    std::fs::write(&filename, wav)?;
-    println!("Saved {}", filename);
+    let output_path = output_dir.join(format!("track{:02}.wav", first_audio.number));
+    std::fs::write(&output_path, wav)?;
+    println!("Saved {}", output_path.display());
 
     Ok(())
 }

--- a/examples/stream_last_track.rs
+++ b/examples/stream_last_track.rs
@@ -1,7 +1,10 @@
 /// Reads the last audio track using the streaming API and saves it as a WAV file.
+mod common;
+
 use cd_da_reader::CdReader;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output_dir = common::fresh_output_dir("stream_last_track")?;
     let reader = CdReader::open_default()?;
     let toc = reader.read_toc()?;
 
@@ -21,9 +24,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let wav = CdReader::create_wav(pcm);
-    let filename = format!("track{:02}.wav", last_audio.number);
-    std::fs::write(&filename, wav)?;
-    println!("Saved {}", filename);
+    let output_path = output_dir.join(format!("track{:02}.wav", last_audio.number));
+    std::fs::write(&output_path, wav)?;
+    println!("Saved {}", output_path.display());
 
     Ok(())
 }

--- a/examples/stream_with_progress.rs
+++ b/examples/stream_with_progress.rs
@@ -1,7 +1,10 @@
 /// Streams the first audio track while printing a live progress line.
+mod common;
+
 use cd_da_reader::CdReader;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output_dir = common::fresh_output_dir("stream_with_progress")?;
     let reader = CdReader::open_default()?;
     let toc = reader.read_toc()?;
 
@@ -32,9 +35,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("\r  [{:.1}s / {:.1}s] 100.0%", total_secs, total_secs);
 
     let wav = CdReader::create_wav(pcm);
-    let filename = format!("track{:02}.wav", first_audio.number);
-    std::fs::write(&filename, wav)?;
-    println!("\nSaved {}", filename);
+    let output_path = output_dir.join(format!("track{:02}.wav", first_audio.number));
+    std::fs::write(&output_path, wav)?;
+    println!("\nSaved {}", output_path.display());
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Update examples to use target output directly (cleaned when using `cargo clean`) and to clean that directory before running any example.